### PR TITLE
[INFRA/CORE] Run golangci-lint more verbosely

### DIFF
--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.33
 
           # Show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+# all available settings of specific linters
+linters-settings:
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0


### PR DESCRIPTION
# Summary

Add `-min-confidence=0` argument to catch more lint errors
