### PR TITLE
[INFRA/CORE] Unrevert #58

### DIFF
--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -13,13 +13,10 @@ func (s *SOMASServer) runTurn() error {
 
 	s.logf("TURN: %v, Season: %v", s.gameState.Turn, s.gameState.Season)
 
-	err := s.updateIslands()
-	if err != nil {
-		return errors.Errorf("Error updating islands: %v", err)
-	}
+	s.startOfTurnUpdate()
 
 	// run all orgs
-	err = s.runOrgs()
+	err := s.runOrgs()
 	if err != nil {
 		return errors.Errorf("Error running orgs: %v", err)
 	}
@@ -51,10 +48,10 @@ func (s *SOMASServer) runOrgs() error {
 	return nil
 }
 
-// updateIsland sends all the island the gameState at the start of the turn.
-func (s *SOMASServer) updateIslands() error {
-	s.logf("start updateIsland")
-	defer s.logf("finish updateIsland")
+// startOfTurnUpdate sends the gameState at the start of the turn to all non-Dead clients.
+func (s *SOMASServer) startOfTurnUpdate() {
+	s.logf("start startOfTurnUpdate")
+	defer s.logf("finish startOfTurnUpdate")
 
 	// send update of entire gameState to alive clients
 	for id, ci := range s.gameState.ClientInfos {
@@ -63,8 +60,20 @@ func (s *SOMASServer) updateIslands() error {
 			c.StartOfTurnUpdate(s.gameState)
 		}
 	}
+}
 
-	return nil
+// gameStateUpdate sends the gameState mid-turn to all non-Dead clients.
+// For use by orgs to update game state after dispatching actions.
+func (s *SOMASServer) gameStateUpdate() {
+	s.logf("start gameStateUpdate")
+	defer s.logf("finish gameStateUpdate")
+
+	for id, ci := range s.gameState.ClientInfos {
+		if ci.LifeStatus != shared.Dead {
+			c := s.clientMap[id]
+			c.GameStateUpdate(s.gameState)
+		}
+	}
 }
 
 // endOfTurn performs end of turn updates

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -4,10 +4,112 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 )
 
+type mockClientUpdate struct {
+	baseclient.Client
+	StartOfTurnUpdateCalled bool
+	GameStateUpdateCalled   bool
+}
+
+func (c *mockClientUpdate) StartOfTurnUpdate(g gamestate.GameState) {
+	c.StartOfTurnUpdateCalled = true
+}
+
+func (c *mockClientUpdate) GameStateUpdate(g gamestate.GameState) {
+	c.GameStateUpdateCalled = true
+}
+
+func TestStartOfTurnUpdate(t *testing.T) {
+	clientInfos := map[shared.ClientID]gamestate.ClientInfo{
+		shared.Team1: {
+			LifeStatus: shared.Alive,
+		},
+		shared.Team2: {
+			LifeStatus: shared.Critical,
+		},
+		shared.Team3: {
+			LifeStatus: shared.Dead,
+		},
+	}
+	clientMap := map[shared.ClientID]baseclient.Client{
+		shared.Team1: &mockClientUpdate{},
+		shared.Team2: &mockClientUpdate{},
+		shared.Team3: &mockClientUpdate{},
+	}
+	wantCalled := map[shared.ClientID]bool{
+		shared.Team1: true,
+		shared.Team2: true,
+		shared.Team3: false,
+	}
+
+	s := &SOMASServer{
+		gameState: gamestate.GameState{
+			ClientInfos: clientInfos,
+		},
+		clientMap: clientMap,
+	}
+
+	s.startOfTurnUpdate()
+
+	for id, want := range wantCalled {
+		v, ok := clientMap[id].(*mockClientUpdate)
+		if !ok {
+			t.Errorf("Can't coerce type!")
+		}
+		got := v.StartOfTurnUpdateCalled
+		if want != got {
+			t.Errorf("For id %v, want '%v' got '%v'", id, want, got)
+		}
+	}
+}
+
+func TestGameStateUpdate(t *testing.T) {
+	clientInfos := map[shared.ClientID]gamestate.ClientInfo{
+		shared.Team1: {
+			LifeStatus: shared.Alive,
+		},
+		shared.Team2: {
+			LifeStatus: shared.Critical,
+		},
+		shared.Team3: {
+			LifeStatus: shared.Dead,
+		},
+	}
+	clientMap := map[shared.ClientID]baseclient.Client{
+		shared.Team1: &mockClientUpdate{},
+		shared.Team2: &mockClientUpdate{},
+		shared.Team3: &mockClientUpdate{},
+	}
+	wantCalled := map[shared.ClientID]bool{
+		shared.Team1: true,
+		shared.Team2: true,
+		shared.Team3: false,
+	}
+
+	s := &SOMASServer{
+		gameState: gamestate.GameState{
+			ClientInfos: clientInfos,
+		},
+		clientMap: clientMap,
+	}
+
+	s.gameStateUpdate()
+
+	for id, want := range wantCalled {
+		v, ok := clientMap[id].(*mockClientUpdate)
+		if !ok {
+			t.Errorf("Can't coerce type!")
+		}
+		got := v.GameStateUpdateCalled
+		if want != got {
+			t.Errorf("For id %v, want '%v' got '%v'", id, want, got)
+		}
+	}
+}
 func TestIncrementTurnAndSeason(t *testing.T) {
 	cases := []struct {
 		name             string


### PR DESCRIPTION
# Summary

#58 was accidentally reverted in an attempt to resolve merge conflicts.


## Test Plan

- Add information on how you tested your changes.

- `go test ./...`
```
?       github.com/SOMAS2020/SOMAS2020  [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team1   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team2   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team3   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team4   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team5   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team6   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/common/baseclient       [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/common/config   [no test files]
ok      github.com/SOMAS2020/SOMAS2020/internal/common/gamestate        (cached)
ok      github.com/SOMAS2020/SOMAS2020/internal/common/rules    (cached)
?       github.com/SOMAS2020/SOMAS2020/internal/common/shared   [no test files]
ok      github.com/SOMAS2020/SOMAS2020/internal/server  (cached)
?       github.com/SOMAS2020/SOMAS2020/pkg/fileutils    [no test files]
?       github.com/SOMAS2020/SOMAS2020/pkg/testutils    [no test files]
```

- `go run .`
```
2020/12/19 13:54:49 [SERVER]: start runTurn
2020/12/19 13:54:49 [SERVER]: TURN: 1, Season: 1
2020/12/19 13:54:49 [SERVER]: start startOfTurnUpdate
2020/12/19 13:54:49 [Team1]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 13:54:49 [Team2]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 13:54:49 [Team3]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 13:54:49 [Team4]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 13:54:49 [Team5]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 13:54:49 [Team6]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 13:54:49 [SERVER]: finish startOfTurnUpdate
2020/12/19 13:54:49 [SERVER]: start runOrgs
2020/12/19 13:54:49 [SERVER]: start runIIGO
2020/12/19 13:54:49 [SERVER]: finish runIIGO
2020/12/19 13:54:49 [SERVER]: start runIIFO
2020/12/19 13:54:49 [SERVER]: finish runIIFO
2020/12/19 13:54:49 [SERVER]: start runIITO
2020/12/19 13:54:49 [SERVER]: finish runIITO
2020/12/19 13:54:49 [SERVER]: finish runOrgs
2020/12/19 13:54:49 [SERVER]: start endOfTurn
2020/12/19 13:54:49 [SERVER]: start probeDisaster
2020/12/19 13:54:49 [SERVER]: finish probeDisaster
2020/12/19 13:54:49 [SERVER]: start incrementTurnAndSeason
2020/12/19 13:54:49 [SERVER]: finish incrementTurnAndSeason
2020/12/19 13:54:49 [SERVER]: start deductCostOfLiving
2020/12/19 13:54:49 [SERVER]: finish deductCostOfLiving
2020/12/19 13:54:49 [SERVER]: start updateIslandLivingStatus
2020/12/19 13:54:49 [SERVER]: finish updateIslandLivingStatus
2020/12/19 13:54:49 [SERVER]: finish endOfTurn
2020/12/19 13:54:49 [SERVER]: finish runTurn
2020/12/19 13:54:49 [SERVER]: start runTurn
2020/12/19 13:54:49 [SERVER]: TURN: 2, Season: 1
2020/12/19 13:54:49 [SERVER]: start startOfTurnUpdate
2020/12/19 13:54:49 [Team5]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 13:54:49 [Team6]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 13:54:49 [Team1]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 13:54:49 [Team2]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 13:54:49 [Team3]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 13:54:49 [Team4]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 13:54:49 [SERVER]: finish startOfTurnUpdate
2020/12/19 13:54:49 [SERVER]: start runOrgs
2020/12/19 13:54:49 [SERVER]: start runIIGO
2020/12/19 13:54:49 [SERVER]: finish runIIGO
2020/12/19 13:54:49 [SERVER]: start runIIFO
2020/12/19 13:54:49 [SERVER]: finish runIIFO
2020/12/19 13:54:49 [SERVER]: start runIITO
2020/12/19 13:54:49 [SERVER]: finish runIITO
2020/12/19 13:54:49 [SERVER]: finish runOrgs
2020/12/19 13:54:49 [SERVER]: start endOfTurn
2020/12/19 13:54:49 [SERVER]: start probeDisaster
2020/12/19 13:54:49 [SERVER]: finish probeDisaster
2020/12/19 13:54:49 [SERVER]: start incrementTurnAndSeason
2020/12/19 13:54:50 [SERVER]: finish incrementTurnAndSeason
2020/12/19 13:54:50 [SERVER]: start deductCostOfLiving
2020/12/19 13:54:50 [SERVER]: finish deductCostOfLiving
2020/12/19 13:54:50 [SERVER]: start updateIslandLivingStatus
2020/12/19 13:54:50 [SERVER]: finish updateIslandLivingStatus
2020/12/19 13:54:50 [SERVER]: finish endOfTurn
2020/12/19 13:54:50 [SERVER]: finish runTurn
2020/12/19 13:54:50 [SERVER]: Max turns '2' reached or exceeded
===== START OF TURN 1 (END OF TURN 0) =====
gamestate.GameState{Season:0x1, Turn:0x1, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}}
===== START OF TURN 2 (END OF TURN 1) =====
gamestate.GameState{Season:0x1, Turn:0x2, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}}
===== START OF TURN 3 (END OF TURN 2) =====
gamestate.GameState{Season:0x1, Turn:0x3, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}}
```