### PR TITLE
[INFRA/CORE] Pass deep copy of GameState to clients

### DIFF
--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -57,7 +57,7 @@ func (s *SOMASServer) startOfTurnUpdate() {
 	for id, ci := range s.gameState.ClientInfos {
 		if ci.LifeStatus != shared.Dead {
 			c := s.clientMap[id]
-			c.StartOfTurnUpdate(s.gameState)
+			c.StartOfTurnUpdate(s.gameState.Copy())
 		}
 	}
 }
@@ -71,7 +71,7 @@ func (s *SOMASServer) gameStateUpdate() {
 	for id, ci := range s.gameState.ClientInfos {
 		if ci.LifeStatus != shared.Dead {
 			c := s.clientMap[id]
-			c.GameStateUpdate(s.gameState)
+			c.GameStateUpdate(s.gameState.Copy())
 		}
 	}
 }


### PR DESCRIPTION
# Summary

Reference types (slices etc.) within GameState may be maliciously changed by clients. Pass a deepcopy instead.

## Test Plan

- Add information on how you tested your changes.

- `go test ./...`
```
?       github.com/SOMAS2020/SOMAS2020  [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team1   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team2   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team3   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team4   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team5   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/clients/team6   [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/common/baseclient       [no test files]
?       github.com/SOMAS2020/SOMAS2020/internal/common/config   [no test files]
ok      github.com/SOMAS2020/SOMAS2020/internal/common/gamestate        0.322s
ok      github.com/SOMAS2020/SOMAS2020/internal/common/rules    (cached)
?       github.com/SOMAS2020/SOMAS2020/internal/common/shared   [no test files]
ok      github.com/SOMAS2020/SOMAS2020/internal/server  0.228s
?       github.com/SOMAS2020/SOMAS2020/pkg/fileutils    [no test files]
?       github.com/SOMAS2020/SOMAS2020/pkg/testutils    [no test files]
```

- `go run .`
```
2020/12/19 20:54:37 [SERVER]: start runTurn
2020/12/19 20:54:37 [SERVER]: TURN: 1, Season: 1
2020/12/19 20:54:37 [SERVER]: start startOfTurnUpdate
2020/12/19 20:54:37 [Team3]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 20:54:37 [Team4]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 20:54:37 [Team5]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 20:54:37 [Team6]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 20:54:37 [Team1]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 20:54:37 [Team2]: Received start of turn game state update: {1 1 map[Team1:{100 Alive 0} Team2:{100 Alive 0} Team3:{100 Alive 0} Team4:{100 Alive 0} Team5:{100 Alive 0} Team6:{100 Alive 0}]}
2020/12/19 20:54:37 [SERVER]: finish startOfTurnUpdate
2020/12/19 20:54:37 [SERVER]: start runOrgs
2020/12/19 20:54:37 [SERVER]: start runIIGO
2020/12/19 20:54:37 [SERVER]: finish runIIGO
2020/12/19 20:54:37 [SERVER]: start runIIFO
2020/12/19 20:54:37 [SERVER]: finish runIIFO
2020/12/19 20:54:37 [SERVER]: start runIITO
2020/12/19 20:54:37 [SERVER]: finish runIITO
2020/12/19 20:54:37 [SERVER]: finish runOrgs
2020/12/19 20:54:37 [SERVER]: start endOfTurn
2020/12/19 20:54:37 [SERVER]: start probeDisaster
2020/12/19 20:54:37 [SERVER]: finish probeDisaster
2020/12/19 20:54:37 [SERVER]: start incrementTurnAndSeason
2020/12/19 20:54:37 [SERVER]: finish incrementTurnAndSeason
2020/12/19 20:54:37 [SERVER]: start deductCostOfLiving
2020/12/19 20:54:37 [SERVER]: finish deductCostOfLiving
2020/12/19 20:54:37 [SERVER]: start updateIslandLivingStatus
2020/12/19 20:54:37 [SERVER]: finish updateIslandLivingStatus
2020/12/19 20:54:37 [SERVER]: finish endOfTurn
2020/12/19 20:54:37 [SERVER]: finish runTurn
2020/12/19 20:54:37 [SERVER]: start runTurn
2020/12/19 20:54:37 [SERVER]: TURN: 2, Season: 1
2020/12/19 20:54:37 [SERVER]: start startOfTurnUpdate
2020/12/19 20:54:37 [Team1]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 20:54:37 [Team2]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 20:54:37 [Team3]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 20:54:37 [Team4]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 20:54:37 [Team5]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 20:54:37 [Team6]: Received start of turn game state update: {1 2 map[Team1:{90 Alive 0} Team2:{90 Alive 0} Team3:{90 Alive 0} Team4:{90 Alive 0} Team5:{90 Alive 0} Team6:{90 Alive 0}]}
2020/12/19 20:54:37 [SERVER]: finish startOfTurnUpdate
2020/12/19 20:54:37 [SERVER]: start runOrgs
2020/12/19 20:54:37 [SERVER]: start runIIGO
2020/12/19 20:54:37 [SERVER]: finish runIIGO
2020/12/19 20:54:37 [SERVER]: start runIIFO
2020/12/19 20:54:37 [SERVER]: finish runIIFO
2020/12/19 20:54:37 [SERVER]: start runIITO
2020/12/19 20:54:37 [SERVER]: finish runIITO
2020/12/19 20:54:37 [SERVER]: finish runOrgs
2020/12/19 20:54:37 [SERVER]: start endOfTurn
2020/12/19 20:54:37 [SERVER]: start probeDisaster
2020/12/19 20:54:37 [SERVER]: finish probeDisaster
2020/12/19 20:54:37 [SERVER]: start incrementTurnAndSeason
2020/12/19 20:54:37 [SERVER]: finish incrementTurnAndSeason
2020/12/19 20:54:37 [SERVER]: start deductCostOfLiving
2020/12/19 20:54:37 [SERVER]: finish deductCostOfLiving
2020/12/19 20:54:37 [SERVER]: start updateIslandLivingStatus
2020/12/19 20:54:37 [SERVER]: finish updateIslandLivingStatus
2020/12/19 20:54:37 [SERVER]: finish endOfTurn
2020/12/19 20:54:37 [SERVER]: finish runTurn
2020/12/19 20:54:37 [SERVER]: Max turns '2' reached or exceeded
===== START OF TURN 1 (END OF TURN 0) =====
gamestate.GameState{Season:0x1, Turn:0x1, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}}
===== START OF TURN 2 (END OF TURN 1) =====
gamestate.GameState{Season:0x1, Turn:0x2, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:90, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}}
===== START OF TURN 3 (END OF TURN 2) =====
gamestate.GameState{Season:0x1, Turn:0x3, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:80, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}}
```