### PR TITLE
[INFRA/CORE] Add note on perm denied log file creation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run
-      run: sudo go run .
+      run: go run .
     - name: Build website
       run: |
         cd website

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Test
       run: go test ./...
     - name: Run
-      run: sudo go run .
+      run: go run .
     - name: Output output.json
-      run: sudo cat output/output.json
+      run: cat output/output.json
     - name: Test build website
       run: |
         cd website

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Main repository for SOMAS2020 Coursework.
 ## Running code
 ```bash
 # Approach 1
-go run .
+go run . # Linux and macOS: Use `sudo go run .` if you encounter any "Permission denied" errors.
 
 # Approach 2
 go build # build step
-./SOMAS2020 # SOMAS2020.exe if you're on Windows
+./SOMAS2020 # SOMAS2020.exe if you're on Windows. Use `sudo` on Linux and macOS as Approach 1 if required.
 ```
 
 ### Output

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func init() {
 		panic(err)
 	}
 	// make output directory
-	err = os.Mkdir(outputDir, 0644)
+	err = os.Mkdir(outputDir, 0777)
 	if err != nil {
 		panic(err)
 	}
@@ -48,9 +48,9 @@ func init() {
 }
 
 func initLogger() {
-	f, err := os.OpenFile(outputLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(outputLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0777)
 	if err != nil {
-		panic("Unable to open log file to output")
+		panic(fmt.Sprintf("Unable to open log file, try running using sudo: %v", err))
 	}
 	log.SetOutput(
 		logger.NewLogWriter([]io.Writer{os.Stderr, f}),
@@ -85,7 +85,7 @@ func outputJSON(o output) {
 		log.Printf("Failed to Marshal gameStates: %v", err)
 		os.Exit(1)
 	}
-	err = ioutil.WriteFile(outputJSONFilePath, jsonBuf, 0644)
+	err = ioutil.WriteFile(outputJSONFilePath, jsonBuf, 0777)
 	if err != nil {
 		log.Printf("Failed to write file: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
# Summary

`sudo` _might be_ required to create a new file on macOS because we're using absolute paths.

## Additional Information
For once, Windoze wins.
Removed `sudo` in CI--not needed as permissions are now `0777`

## Test Plan
¯\\_(ツ)_/¯

Tested with @preetl 
