### PR TITLE
Revert "[INFRA/CORE] Add base branch edit trigger for lint and test in CI"

### DIFF
--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, edited, reopened]
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, edited, reopened]
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Reverts SOMAS2020/SOMAS2020#68

Now that a setting has been added to force all PRs to be up-to-date with the base branch (main), this is no longer required. It's also really annoying because it reruns CI when the PR description is edited.