### PR TITLE
common-pool added

### DIFF
--- a/internal/common/disasters/commonpooldefinition.go
+++ b/internal/common/disasters/commonpooldefinition.go
@@ -10,8 +10,8 @@ type Commonpool struct {
 }
 
 //islandContribution takes the resource donation from island to common pool
-func (e Environment) islandContribution(resource uint) {
-	e.CommonPool.Resource = resource
+func (e *Environment) islandContribution(resource uint) {
+	e.CommonPool.Resource += resource
 }
 
 //disasterMitigate mitigates the disaster's damage using CP efore it hits the island

--- a/internal/common/disasters/commonpooldefinition.go
+++ b/internal/common/disasters/commonpooldefinition.go
@@ -1,0 +1,55 @@
+package disasters
+
+import (
+
+	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+)
+
+type Commonpool struct {
+	Resource, Threshold  uint
+}
+
+//islandContribution takes the resource donation from island to common pool
+func (e Environment) islandContribution(resource uint) {
+	e.CommonPool.Resource = resource
+}
+
+//disasterMitigate mitigates the disaster's damage using CP efore it hits the island
+func (e *Environment) DisasterMitigate(individualEffect map[shared.ClientID]float64, proportionalEffect map[shared.ClientID]float64) (map[shared.ClientID]float64, uint) {				//input is the porportional effect of each island
+	// compute total effect of disaster
+	totalEffect := 0.0
+	updatedIndividualEffect := map[shared.ClientID]float64{}
+
+	for _, effect := range individualEffect {
+		totalEffect = totalEffect + effect
+	}
+
+	// compute cp power towards disaster
+	var newmag float64
+	tempResource := float64(e.CommonPool.Resource)
+	if e.CommonPool.Resource >= e.CommonPool.Threshold { //exceeds cp threshold
+		newmag = (totalEffect / 2) * 1000 // better prep means less effect
+	} else {
+		newmag = totalEffect * 1000 // no prep so goodluck
+	}
+
+	//compufte reminant effect for each island
+	if newmag <= tempResource { //magn*1000 => effect in resource unit
+		tempResource = tempResource - newmag
+		for islandID, _ := range individualEffect {
+			updatedIndividualEffect[islandID] = 0 // 0 means fully mitigated
+		}
+	} else {
+
+		leftover_effect := newmag-tempResource  //disaster that has to be mitigated by islands
+		tempResource = 0                              // nothing remains in the cp
+		for islandID, effect := range proportionalEffect {
+			updatedIndividualEffect[islandID] = leftover_effect * effect // 0 means fully mitigated
+		}
+	}
+	e.CommonPool.Resource = uint(tempResource)
+	//log.Printf("\nCommon pool resource the end of mitigation: %d\n", e.CommonPool.Resource)
+	return updatedIndividualEffect, uint(tempResource) 					//the leftover effect that islands need to mitigate by their own resources
+}
+
+

--- a/internal/common/disasters/environmentdefinition.go
+++ b/internal/common/disasters/environmentdefinition.go
@@ -2,7 +2,6 @@ package disasters
 
 import (
 	"math"
-
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"gonum.org/v1/gonum/stat/distuv"
 )
@@ -37,6 +36,7 @@ type Environment struct {
 	geography          ArchipelagoGeography
 	disasterParams     DisasterParameters
 	lastDisasterReport DisasterReport
+	CommonPool		   Commonpool
 }
 
 // SampleForDisaster samples the stochastic disaster process to see if a disaster occurred
@@ -68,4 +68,22 @@ func (e Environment) DisasterEffects() map[shared.ClientID]float64 {
 		out[island.id] = e.lastDisasterReport.magnitude / (math.Sqrt(math.Pow(island.x-epiX, 2) + math.Pow(island.y-epiY, 2))) // effect on island i is inverse prop. to square of distance to epicentre
 	}
 	return out
+}
+
+// DisasterEffects returns the porportional effects of the most recent DisasterReport held in the environment state
+func (e Environment) DisasterPorpotionalEffects() map[shared.ClientID]float64 {
+	out := map[shared.ClientID]float64{}                         // TODO: change key type to ClientID
+	porportionalEffect := map[shared.ClientID]float64{}
+	totalEffect := 0.0   
+
+	epiX, epiY := e.lastDisasterReport.x, e.lastDisasterReport.x // epicentre of the disaster (peak mag)
+	for _, island := range e.geography.islands {
+		out[island.id] = e.lastDisasterReport.magnitude / (math.Sqrt(math.Pow(island.x-epiX, 2) + math.Pow(island.y-epiY, 2))) // effect on island i is inverse prop. to square of distance to epicentre
+		totalEffect = totalEffect + out[island.id]
+	}
+	for _, island := range e.geography.islands {
+		porportionalEffect[island.id] =  out[island.id] / totalEffect
+	}
+
+	return porportionalEffect
 }

--- a/internal/common/disasters/environmentregistration.go
+++ b/internal/common/disasters/environmentregistration.go
@@ -3,7 +3,7 @@ package disasters
 import "github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 
 // InitEnvironment initialises environment according to definitions
-func InitEnvironment(islandIDs []shared.ClientID, xBounds [2]float64, yBounds [2]float64, disasterParams DisasterParameters) (*Environment, error) {
+func InitEnvironment(islandIDs []shared.ClientID, xBounds [2]float64, yBounds [2]float64, disasterParams DisasterParameters, cp Commonpool) (*Environment, error) {
 
 	ag := ArchipelagoGeography{map[shared.ClientID]Island{}, xBounds, yBounds}
 
@@ -11,5 +11,5 @@ func InitEnvironment(islandIDs []shared.ClientID, xBounds [2]float64, yBounds [2
 		island := Island{id, float64(i), float64(0)} // begin with points on x axis
 		ag.islands[id] = island
 	}
-	return &Environment{ag, disasterParams, DisasterReport{}}, nil // may want ability to return error in future
+	return &Environment{ag, disasterParams, DisasterReport{}, cp}, nil // may want ability to return error in future
 }

--- a/internal/server/disaster.go
+++ b/internal/server/disaster.go
@@ -1,8 +1,20 @@
 package server
 
+import (
+	"fmt"
+)
 // probeDisaster checks if a disaster occurs this turn
 func (s *SOMASServer) probeDisaster() (bool, error) {
 	s.logf("start probeDisaster")
+
+	s.gameState.Environment.SampleForDisaster()
+
+	disasterReport, leftover_damage := s.gameState.Environment.DisplayReport()
+	fmt.Println(disasterReport)
+	s.islandDistribute(s.gameState.Environment.CommonPool.Resource, disasterReport)
+	s.islandDeplete(leftover_damage)
+
+
 	defer s.logf("finish probeDisaster")
 	// TODO:- env team
 	return false, nil


### PR DESCRIPTION
Add common-pool definitions
Common-pool is a variable in struct environments
Everytime a disaster happen, 
+ cp mitigates the disaster 
+ distribute the leftover resource (if there is) 
 + or further deplete island's resource based on the leftover damage of disaster