### PR TITLE
[INFRA/CORE] Added .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.go text
+*.json text


### PR DESCRIPTION
# Summary

Added a `.gitattributes` file. This is because different systems use different line endings which can sometimes cause large whitespace commits or annoying to resolve merge issues. See pr #89 for what may potentially be a symptom of this.
