### PR TITLE
[INFRA/CORE] Adjust linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,6 +15,13 @@ jobs:
         uses: reviewdog/action-golangci-lint@v1
         with: 
           tool_name: golangci-lint
+
+  golangci-lint-other:
+    name: golangci-lint
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
       - name: golint
         uses: reviewdog/action-golangci-lint@v1
         with:

--- a/internal/server/disaster.go
+++ b/internal/server/disaster.go
@@ -1,9 +1,15 @@
 package server
 
+import "fmt"
+
 // probeDisaster checks if a disaster occurs this turn
 func (s *SOMASServer) probeDisaster() (bool, error) {
 	s.logf("start probeDisaster")
 	defer s.logf("finish probeDisaster")
 	// TODO:- env team
 	return false, nil
+}
+
+func ServerReee() {
+	fmt.Println("REE")
 }


### PR DESCRIPTION
As title. Appearing as errors is a bit too aggressive. Separate the jobs and make the other stricter linters return warnings.