### PR TITLE
[INFRA/CORE] Make golint super pedantic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+issues:
+  exclude-use-default: false


### PR DESCRIPTION
Add a `.golangci.yml` file for `golangci-lint` to use. Set it to
``` 
issues:
  exclude-use-default: false
```
to unlock the pedantic golint floodgates

Ref: https://golangci-lint.run/usage/configuration/

Test Plan:

These weren't visible before:
![image](https://user-images.githubusercontent.com/33488131/102836108-6889b780-43f0-11eb-92ae-1eb5b25eed52.png)
