### PR TITLE
[INFRA/CORE] Fail on some lint errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,6 +15,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v1
         with: 
           tool_name: golangci-lint
+          fail_on_error: true
       - name: golint
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -33,6 +34,7 @@ jobs:
           golangci_lint_flags: "--disable-all -E exhaustive"
           tool_name: exhaustive 
           level: warning 
+          fail_on_error: true
       - name: exhaustivestruct
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -45,3 +47,4 @@ jobs:
           golangci_lint_flags: "--disable-all -E goimports"
           tool_name: goimports 
           level: warning
+          fail_on_error: true


### PR DESCRIPTION
Linter does not fail on some errors... just realised we need a `fail_on_error` flag!

Fail on the following linters:
- golangci-lint
```
deadcode - Finds unused code
errcheck - Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
gosimple - Linter for Go source code that specializes in simplifying a code
govet - Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
ineffassign - Detects when assignments to existing variables are not used
staticcheck - Staticcheck is a go vet on steroids, applying a ton of static analysis checks
structcheck - Finds unused struct fields
typecheck - Like the front-end of a Go compiler, parses and type-checks Go code
unused - Checks Go code for unused constants, variables, functions and types
varcheck - Finds unused global variables and constants
```
- exhaustive - check exhaustiveness of enum switch statements
- goimports - Goimports does everything that gofmt does. Additionally it checks unused imports