### PR TITLE
[INFRA/CORE] Don't deduct resources below 0 in deductCostOfLiving

### DIFF
--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -173,7 +173,11 @@ func (s *SOMASServer) deductCostOfLiving(costOfLiving int) {
 	for _, id := range nonDeadClients {
 		go func(id shared.ClientID, ci gamestate.ClientInfo) {
 			defer wg.Done()
-			ci.Resources -= costOfLiving
+			if ci.Resources < costOfLiving {
+				ci.Resources = 0
+			} else {
+				ci.Resources -= costOfLiving
+			}
 			resChan <- clientInfoUpdateResult{
 				ID:  id,
 				Ci:  ci,

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -178,6 +178,10 @@ func TestDeductCostOfLiving(t *testing.T) {
 			Resources:  45,
 			LifeStatus: shared.Dead,
 		},
+		shared.Team4: {
+			Resources:  20,
+			LifeStatus: shared.Alive,
+		},
 	}
 	wantClientInfos := map[shared.ClientID]gamestate.ClientInfo{
 		shared.Team1: {
@@ -191,6 +195,10 @@ func TestDeductCostOfLiving(t *testing.T) {
 		shared.Team3: {
 			Resources:  45,
 			LifeStatus: shared.Dead,
+		},
+		shared.Team4: {
+			Resources:  0,
+			LifeStatus: shared.Alive,
 		},
 	}
 


### PR DESCRIPTION
# Summary

Previously it was thought that an island can "owe" resources and have negative resources that they need to recoup.

That idea was trash.

## Test Plan

added unit test.