### PR TITLE
[INFRA/CORE] Make foraging update resources, notify agents of their foraging returns

### DIFF
--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -42,6 +42,7 @@ type Client interface {
 
 	//Foraging
 	DecideForage() (shared.ForageDecision, error)
+	ForageUpdate(forageReturn int)
 
 	//IITO: COMPULSORY
 	RequestGift() uint

--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -42,6 +42,7 @@ type Client interface {
 
 	//Foraging
 	DecideForage() (shared.ForageDecision, error)
+	ForageUpdate(shared.Resources)
 
 	//IITO: COMPULSORY
 	RequestGift() uint

--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -42,7 +42,10 @@ type Client interface {
 
 	//Foraging
 	DecideForage() (shared.ForageDecision, error)
-	ForageUpdate(shared.Resources)
+
+	// ForageUpdate is called with the total resources returned to the agent
+	// from the hunt (NOT the profit)
+	ForageUpdate(shared.ForageDecision, shared.Resources)
 
 	//IITO: COMPULSORY
 	RequestGift() uint

--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -42,7 +42,6 @@ type Client interface {
 
 	//Foraging
 	DecideForage() (shared.ForageDecision, error)
-	ForageUpdate(forageReturn int)
 
 	//IITO: COMPULSORY
 	RequestGift() uint

--- a/internal/common/baseclient/forage.go
+++ b/internal/common/baseclient/forage.go
@@ -9,5 +9,8 @@ import (
 // DecideForage makes a foraging decision, currently you can only forage deer, but fishing will be available later
 // the forageContribution can not be larger than the total resources available
 func (c *BaseClient) DecideForage() (shared.ForageDecision, error) {
-	return shared.ForageDecision{Type: shared.DeerForageType, Contribution: shared.Resources(rand.Float64() * 100)}, nil
+	return shared.ForageDecision{
+		Type: shared.DeerForageType,
+		Contribution: shared.Resources(rand.Float64() * 5),
+	}, nil
 }

--- a/internal/common/baseclient/forage.go
+++ b/internal/common/baseclient/forage.go
@@ -14,3 +14,5 @@ func (c *BaseClient) DecideForage() (shared.ForageDecision, error) {
 		Contribution: shared.Resources(rand.Float64() * 5),
 	}, nil
 }
+
+func (c *BaseClient) ForageUpdate(shared.Resources) {}

--- a/internal/common/baseclient/forage.go
+++ b/internal/common/baseclient/forage.go
@@ -15,4 +15,4 @@ func (c *BaseClient) DecideForage() (shared.ForageDecision, error) {
 	}, nil
 }
 
-func (c *BaseClient) ForageUpdate(shared.Resources) {}
+func (c *BaseClient) ForageUpdate(shared.ForageDecision, shared.Resources) {}

--- a/internal/common/baseclient/forage.go
+++ b/internal/common/baseclient/forage.go
@@ -10,7 +10,7 @@ import (
 // the forageContribution can not be larger than the total resources available
 func (c *BaseClient) DecideForage() (shared.ForageDecision, error) {
 	return shared.ForageDecision{
-		Type: shared.DeerForageType,
+		Type:         shared.DeerForageType,
 		Contribution: shared.Resources(rand.Float64() * 5),
 	}, nil
 }

--- a/internal/common/baseclient/forage.go
+++ b/internal/common/baseclient/forage.go
@@ -11,5 +11,3 @@ import (
 func (c *BaseClient) DecideForage() (shared.ForageDecision, error) {
 	return shared.ForageDecision{Type: shared.DeerForageType, Contribution: shared.Resources(rand.Float64() * 100)}, nil
 }
-
-func (c *BaseClient) ForageUpdate(forageReturn int) {}

--- a/internal/common/baseclient/forage.go
+++ b/internal/common/baseclient/forage.go
@@ -11,3 +11,5 @@ import (
 func (c *BaseClient) DecideForage() (shared.ForageDecision, error) {
 	return shared.ForageDecision{Type: shared.DeerForageType, Contribution: shared.Resources(rand.Float64() * 100)}, nil
 }
+
+func (c *BaseClient) ForageUpdate(forageReturn int) {}

--- a/internal/common/shared/forage.go
+++ b/internal/common/shared/forage.go
@@ -1,7 +1,9 @@
 package shared
 
+import "fmt"
+
 // ForageType selects which resource the agents want to forage in
-type ForageType = int
+type ForageType int
 
 const (
 	// DeerForageType is hunting resource, it is described at length in foraging package
@@ -18,3 +20,14 @@ type ForageDecision struct {
 
 // ForagingDecisionsDict is a map of clients' foraging decisions
 type ForagingDecisionsDict = map[ClientID]ForageDecision
+
+func (ft ForageType) String() string {
+	switch ft {
+	case DeerForageType:
+		return "DeerForageType"
+	case FishForageType:
+		return "FishForageType"
+	default:
+		return fmt.Sprintf("InvalidForageType(%d)", ft)
+	}
+}

--- a/internal/common/shared/forage.go
+++ b/internal/common/shared/forage.go
@@ -1,6 +1,10 @@
 package shared
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
+)
 
 // ForageType selects which resource the agents want to forage in
 type ForageType int
@@ -22,12 +26,24 @@ type ForageDecision struct {
 type ForagingDecisionsDict = map[ClientID]ForageDecision
 
 func (ft ForageType) String() string {
-	switch ft {
-	case DeerForageType:
-		return "DeerForageType"
-	case FishForageType:
-		return "FishForageType"
-	default:
-		return fmt.Sprintf("InvalidForageType(%d)", ft)
+	strings := [...]string{"DeerForageType", "FishForageType"}
+	if ft >= 0 && int(ft) < len(strings) {
+		return strings[ft]
 	}
+	return fmt.Sprintf("UNKNOWN ForageType '%v'", int(ft))
+}
+
+// GoString implements GoStringer
+func (ft ForageType) GoString() string {
+	return ft.String()
+}
+
+// MarshalText implements TextMarshaler
+func (ft ForageType) MarshalText() ([]byte, error) {
+	return miscutils.MarshalTextForString(ft.String())
+}
+
+// MarshalJSON implements RawMessage
+func (ft ForageType) MarshalJSON() ([]byte, error) {
+	return miscutils.MarshalJSONForString(ft.String())
 }

--- a/internal/server/forage.go
+++ b/internal/server/forage.go
@@ -61,7 +61,9 @@ func (s *SOMASServer) runDeerHunt(participants map[shared.ClientID]shared.Resour
 	for _, contribution := range participants { totalContributions += contribution }
 
 	for participantID, contribution := range participants {
-		s.giveResources(participantID, (contribution/totalContributions) * totalReturn, "Deer hunt return")
+		participantReturn := (contribution/totalContributions) * totalReturn
+		s.giveResources(participantID, participantReturn, "Deer hunt return")
+		s.clientMap[participantID].ForageUpdate(participantReturn)
 	}
 
 	s.logf("Hunt generated a return of %.3f from input of %.3f", totalReturn, hunt.TotalInput())

--- a/internal/server/forage_test.go
+++ b/internal/server/forage_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+)
+
+type mockClientForage struct {
+	baseclient.Client
+
+	forageDecision        shared.ForageDecision
+	got_forageUpdateValue shared.Resources
+}
+
+func (c mockClientForage) DecideForage() (shared.ForageDecision, error) {
+	return c.forageDecision, nil
+}
+
+func (c *mockClientForage) ForageUpdate(resources shared.Resources) {
+	c.got_forageUpdateValue = resources
+}
+
+func TestForagingCallsForageUpdate(t *testing.T) {
+	cases := []shared.ForageType{
+		shared.DeerForageType,
+		// TODO: Uncomment when fish foraging implemented
+		// shared.FishForageType,
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			client := mockClientForage{
+				forageDecision: shared.ForageDecision{
+					Type:         tc,
+					Contribution: 10,
+				},
+
+				got_forageUpdateValue: -1,
+			}
+
+			s := SOMASServer{
+				gameState: gamestate.GameState{
+					ClientInfos: map[shared.ClientID]gamestate.ClientInfo{
+						shared.Team1: {
+							LifeStatus: shared.Alive,
+							Resources: 100,
+						},
+					},
+				},
+				clientMap: map[shared.ClientID]baseclient.Client{
+					shared.Team1: &client,
+				},
+			}
+
+			s.runForage()
+
+			if client.got_forageUpdateValue < 0 {
+				t.Errorf("ForageUpdate was not called (%v)", client.got_forageUpdateValue)
+			}
+
+		})
+	}
+}

--- a/internal/server/helper.go
+++ b/internal/server/helper.go
@@ -37,7 +37,7 @@ func anyClientsAlive(clientInfos map[shared.ClientID]gamestate.ClientInfo) bool 
 }
 
 // getNonDeadClients returns a map of all clients with a non-dead status
-func getNonDeadClients(clientInfos map[shared.ClientID]gamestate.ClientInfo, 
+func getNonDeadClients(clientInfos map[shared.ClientID]gamestate.ClientInfo,
 	clientMap map[shared.ClientID]baseclient.Client) map[shared.ClientID]baseclient.Client {
 
 	nonDeadClientMap := map[shared.ClientID]baseclient.Client{}
@@ -100,4 +100,30 @@ func getNonDeadClientIDs(clientInfos map[shared.ClientID]gamestate.ClientInfo) [
 	}
 
 	return nonDeadClients
+}
+
+// giveResources takes resources to client, logging it and mentioning reason
+func (s *SOMASServer) takeResources(clientID shared.ClientID, resources shared.Resources, reason string) error {
+	s.logf("Took %v from %v (reason: %s)", resources, clientID, reason)
+
+	participantInfo := s.gameState.ClientInfos[clientID]
+	if participantInfo.Resources < resources {
+		return errors.Errorf(
+			"Client %v did not have enough resources. Requested %v, only had %v",
+			clientID, resources, participantInfo.Resources,
+		)
+	}
+	participantInfo.Resources -= resources
+	s.gameState.ClientInfos[clientID] = participantInfo
+	return nil
+}
+
+// giveResources gives resources to client, logging it and mentioning reason
+func (s *SOMASServer) giveResources(clientID shared.ClientID, resources shared.Resources, reason string) {
+	s.logf("Gave %v to %v (reason: %s)", resources, clientID, reason)
+
+	participantInfo := s.gameState.ClientInfos[clientID]
+	participantInfo.Resources += resources
+	s.gameState.ClientInfos[clientID] = participantInfo
+
 }

--- a/internal/server/helper_test.go
+++ b/internal/server/helper_test.go
@@ -266,3 +266,44 @@ func TestTakeResources(t *testing.T) {
 		})
 	}
 }
+
+func TestGiveResources(t *testing.T) {
+	cases := []struct {
+		name      string
+		resources shared.Resources
+		giveAmt   shared.Resources
+		want      shared.Resources
+	}{
+		{
+			name:      "normal",
+			resources: 42,
+			giveAmt:   3,
+			want:      45,
+		},
+		{
+			name:      "Give 0",
+			resources: 42,
+			giveAmt:   0,
+			want:      42,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := SOMASServer{
+				gameState: gamestate.GameState{
+					ClientInfos: map[shared.ClientID]gamestate.ClientInfo{
+						shared.Team1: {Resources: tc.resources},
+					},
+				},
+			}
+
+			s.giveResources(shared.Team1, tc.giveAmt, tc.name)
+			got := s.gameState.ClientInfos[shared.Team1].Resources
+
+			if tc.want != got {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/server/iigointernal/base_president_test.go
+++ b/internal/server/iigointernal/base_president_test.go
@@ -370,7 +370,6 @@ func TestGetRuleForSpeaker(t *testing.T) {
 	}
 }
 
-// FIXME: @mpardalos could not get this running
 func TestGetAllocationRequests(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
## Summary
This PR makes 2 changes:
+ Makes foraging actually update the clients' resources; first taking away the contributed resources and then giving back the foraging results.
+ Adds a `ForageUpdate` function on the Client that gets called when foraging is finished to with the foraging returns

This PR makes an implicit design decision:
*Foraging rewards are distributed proportional to participants' contributions*. It could easily be changed to be an equal split, or some other method.