### PR TITLE
[INFRA/CORE] BEGONE CONCURRENCY

### DIFF
--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -165,33 +165,13 @@ func (s *SOMASServer) deductCostOfLiving(costOfLiving shared.Resources) {
 	defer s.logf("finish deductCostOfLiving")
 
 	nonDeadClients := getNonDeadClientIDs(s.gameState.ClientInfos)
-	N := len(nonDeadClients)
-	resChan := make(chan clientInfoUpdateResult, N)
-	wg := &sync.WaitGroup{}
-	wg.Add(N)
-
 	for _, id := range nonDeadClients {
-		go func(id shared.ClientID, ci gamestate.ClientInfo) {
-			defer wg.Done()
-			if ci.Resources < costOfLiving {
-				ci.Resources = 0
-			} else {
-				ci.Resources -= costOfLiving
-			}
-			resChan <- clientInfoUpdateResult{
-				ID:  id,
-				Ci:  ci,
-				Err: nil,
-			}
-		}(id, s.gameState.ClientInfos[id])
-	}
-
-	wg.Wait()
-	close(resChan)
-
-	for res := range resChan {
-		id, ci := res.ID, res.Ci
-		// fine to ignore error, always nil
+		ci := s.gameState.ClientInfos[id]
+		if ci.Resources < costOfLiving {
+			ci.Resources = 0
+		} else {
+			ci.Resources -= costOfLiving
+		}
 		s.gameState.ClientInfos[id] = ci
 	}
 }
@@ -204,29 +184,9 @@ func (s *SOMASServer) updateIslandLivingStatus() error {
 	defer s.logf("finish updateIslandLivingStatus")
 
 	nonDeadClients := getNonDeadClientIDs(s.gameState.ClientInfos)
-	N := len(nonDeadClients)
-	resChan := make(chan clientInfoUpdateResult, N)
-	wg := &sync.WaitGroup{}
-	wg.Add(N)
-
 	for _, id := range nonDeadClients {
-		go func(id shared.ClientID, ci gamestate.ClientInfo) {
-			defer wg.Done()
-			ciNew, err := updateIslandLivingStatusForClient(ci,
-				config.GameConfig().MinimumResourceThreshold, config.GameConfig().MaxCriticalConsecutiveTurns)
-			resChan <- clientInfoUpdateResult{
-				ID:  id,
-				Ci:  ciNew,
-				Err: err,
-			}
-		}(id, s.gameState.ClientInfos[id])
-	}
-
-	wg.Wait()
-	close(resChan)
-
-	for res := range resChan {
-		id, ci, err := res.ID, res.Ci, res.Err
+		ci, err := updateIslandLivingStatusForClient(s.gameState.ClientInfos[id],
+			config.GameConfig().MinimumResourceThreshold, config.GameConfig().MaxCriticalConsecutiveTurns)
 		if err != nil {
 			return errors.Errorf("Failed to update island living status for '%v': %v", id, err)
 		}


### PR DESCRIPTION
This has caused so much pain. People have asked what `resChan` is, well, she's my girlfriend. She's from Japan, yeah: res-chan.

here's a picture of her
![image](https://user-images.githubusercontent.com/33488131/103111553-2bb6fe00-4646-11eb-9828-e7c5d0a97f4f.png)


Also, people have been copying this code assuming it is gospel (it is not, none of my dog shit code is), and have been using channels inadvertently. 

Merry Xmas 

and have a happy new year

![image](https://user-images.githubusercontent.com/33488131/103111578-6d47a900-4646-11eb-9fef-ebc78e7db8c2.png)

There is more concurrency in the `GameStateUpdate` stuff, but #139 will get rid of this.

## Test Plan

I ALREADY HAVE UNIT TESTS FOR THIS BRO. THAT'S THE POINT. THEY RUN! AND THEY PASS! AND I DON'T NEED TO WORRY!