### PR TITLE
[INFRA/CORE] Allow CLI overriding of game config

### DIFF
--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -1,5 +1,6 @@
-// Package config contains configurations of the game.
+// Package config contains types for the configuration of the game.
 // DO NOT depend on other packages outside this folder!
+// Add default values etc. in <root>/params.go
 package config
 
 import "github.com/SOMAS2020/SOMAS2020/internal/common/shared"
@@ -12,13 +13,13 @@ type Config struct {
 	// MaxTurns is the maximum numbers of 1-indexed turns to run the game.
 	MaxTurns uint
 
-	// InitialResources is the default number of resources at the start of the game
+	// InitialResources is the default number of resources at the start of the game.
 	InitialResources shared.Resources
 
 	// CostOfLiving is subtracted from an islands pool before
-	// the next term. This is the simulation-level equivalent to using resources to stay
+	// the next turn. This is the simulation-level equivalent to using resources to stay
 	// alive (e.g. food consumed). These resources are permanently consumed and do
-	// NOT go into the common pool. Note: this is NOT the same as the tax
+	// NOT go into the common pool. Note: this is NOT the same as the tax.
 	CostOfLiving shared.Resources
 
 	// MinimumResourceThreshold is the minimum resources required for an island to not be
@@ -38,13 +39,13 @@ type Config struct {
 // ForagingConfig captures foraging-specific config
 type ForagingConfig struct {
 	// Deer Hunting
-	MaxDeerPerHunt        uint    // Maximimum possible number of deer on a single hunt (regardless of number of participants)
+	MaxDeerPerHunt        uint    // Max possible number of deer on a single hunt (regardless of number of participants)
 	IncrementalInputDecay float64 // Determines decay of incremental input cost of hunting more deer
 	BernoulliProb         float64 // `p` param in D variable (see README). Controls prob of catching a deer or not
 	ExponentialRate       float64 // `lambda` param in W variable (see README). Controls distribution of deer sizes.
 
 	// Deer Population
-	MaxDeerPopulation     uint    // Maximimum possible deer population. Reserved for post-MVP functionality
+	MaxDeerPopulation     uint    // Max possible deer population. Reserved for post-MVP functionality
 	DeerGrowthCoefficient float64 // Scaling parameter used in the population model. Larger coeff => deer pop. regenerates faster
 
 	// TODO: add other pertinent params here (for fishing etc)
@@ -56,38 +57,4 @@ type DisasterConfig struct {
 	GlobalProb             float64               // Bernoulli 'p' param. Chance of a disaster occurring
 	SpatialPDFType         shared.SpatialPDFType // Set x,y prob. distribution of the disaster's epicentre (more post MVP)
 	MagnitudeLambda        float64               // Exponential rate param for disaster magnitude
-}
-
-// GameConfig returns the configuration of the game.
-// (Made a function so it cannot be altered mid-game).
-func GameConfig() Config {
-	foragingConf := ForagingConfig{
-		MaxDeerPerHunt:        4,
-		IncrementalInputDecay: 0.8,
-		BernoulliProb:         0.95,
-		ExponentialRate:       1,
-
-		MaxDeerPopulation:     12,
-		DeerGrowthCoefficient: 0.4,
-	}
-	disasterConf := DisasterConfig{
-		XMin:            0.0,
-		XMax:            10.0, // chosen quite arbitrarily for now
-		YMin:            0.0,
-		YMax:            10.0,
-		GlobalProb:      0.1,
-		SpatialPDFType:  shared.Uniform,
-		MagnitudeLambda: 1.0,
-	}
-
-	return Config{
-		MaxSeasons:                  100,
-		MaxTurns:                    100,
-		InitialResources:            100,
-		CostOfLiving:                10,
-		MinimumResourceThreshold:    5,
-		MaxCriticalConsecutiveTurns: 3,
-		ForagingConfig:              foragingConf,
-		DisasterConfig:              disasterConf,
-	}
 }

--- a/internal/common/disasters/setup.go
+++ b/internal/common/disasters/setup.go
@@ -6,9 +6,7 @@ import (
 )
 
 // InitEnvironment initialises environment according to definitions
-func InitEnvironment(islandIDs []shared.ClientID) Environment {
-	envConf := config.GameConfig().DisasterConfig
-
+func InitEnvironment(islandIDs []shared.ClientID, envConf config.DisasterConfig) Environment {
 	ag := ArchipelagoGeography{
 		Islands: map[shared.ClientID]IslandLocationInfo{},
 		XMin:    envConf.XMin,

--- a/internal/common/foraging/deerhunt.go
+++ b/internal/common/foraging/deerhunt.go
@@ -31,9 +31,7 @@ func (d DeerHunt) TotalInput() shared.Resources {
 }
 
 // Hunt returns the utility from a deer hunt
-func (d DeerHunt) Hunt() shared.Resources {
-	fConf := config.GameConfig().ForagingConfig
-
+func (d DeerHunt) Hunt(fConf config.ForagingConfig) shared.Resources {
 	input := d.TotalInput()
 	decay := fConf.IncrementalInputDecay
 	maxDeer := fConf.MaxDeerPerHunt

--- a/internal/common/foraging/deerhunt_test.go
+++ b/internal/common/foraging/deerhunt_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 )
 
@@ -37,8 +38,17 @@ func TestDeerUtilityTier(t *testing.T) {
 }
 
 func TestTotalInput(t *testing.T) {
+	fConf := config.ForagingConfig{
+		MaxDeerPerHunt:        4,
+		IncrementalInputDecay: 0.8,
+		BernoulliProb:         0.95,
+		ExponentialRate:       1,
+
+		MaxDeerPopulation:     12,
+		DeerGrowthCoefficient: 0.4,
+	}
 	huntParticipants := map[shared.ClientID]shared.Resources{shared.Team1: 1.0, shared.Team2: 0.9} // arbitrarily chosen for test
-	hunt, _ := CreateDeerHunt(huntParticipants)
+	hunt, _ := CreateDeerHunt(huntParticipants, fConf)
 	ans := hunt.TotalInput()
 	if ans != 1.9 {
 		t.Errorf("TotalInput() = %.2f; want 1.9", ans)

--- a/internal/common/foraging/deerpopulation.go
+++ b/internal/common/foraging/deerpopulation.go
@@ -23,8 +23,7 @@ func (dp *DeerPopulationModel) Logf(format string, a ...interface{}) {
 }
 
 // CreateBasicDeerPopulationModel returns a basic population model based on dP/dt = k(N-y) model. k = growth coeff., N = max deer (constants).
-func createBasicDeerPopulationModel() DeerPopulationModel {
-	fConf := config.GameConfig().ForagingConfig
+func createBasicDeerPopulationModel(fConf config.ForagingConfig) DeerPopulationModel {
 	// definition of deer pop. gradient. Provides dy/dt given y, t.
 	maxDeer := fConf.MaxDeerPopulation
 	deerPopulationGrowth := func(t, y float64) float64 {

--- a/internal/common/foraging/setup.go
+++ b/internal/common/foraging/setup.go
@@ -6,13 +6,12 @@ import (
 )
 
 // CreateDeerHunt receives hunt participants and their contributions and returns a DeerHunt
-func CreateDeerHunt(teamResourceInputs map[shared.ClientID]shared.Resources) (DeerHunt, error) {
-	fConf := config.GameConfig().ForagingConfig
+func CreateDeerHunt(teamResourceInputs map[shared.ClientID]shared.Resources, fConf config.ForagingConfig) (DeerHunt, error) {
 	params := deerHuntParams{p: fConf.BernoulliProb, lam: fConf.ExponentialRate}
 	return DeerHunt{ParticipantContributions: teamResourceInputs, params: params}, nil // returning error too for future use
 }
 
 // CreateDeerPopulationModel returns the target population model. The formulation of this model should be changed here before runtime
-func CreateDeerPopulationModel() DeerPopulationModel {
-	return createBasicDeerPopulationModel()
+func CreateDeerPopulationModel(fConf config.ForagingConfig) DeerPopulationModel {
+	return createBasicDeerPopulationModel(fConf)
 }

--- a/internal/common/shared/disasters.go
+++ b/internal/common/shared/disasters.go
@@ -1,5 +1,12 @@
 package shared
 
+import (
+	"fmt"
+	"log"
+
+	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
+)
+
 // Coordinate is a floating point number that can be used represent a position on the map
 type Coordinate = float64
 
@@ -14,4 +21,50 @@ const (
 	Uniform SpatialPDFType = iota
 
 	// add other PDFs here post-MVP
+
+	// DO NOT TOUCH THIS
+	spatialPDFTypeEnd
 )
+
+func (s SpatialPDFType) String() string {
+	strings := [...]string{"Uniform"}
+	if s >= 0 && int(s) < len(strings) {
+		return strings[s]
+	}
+	return fmt.Sprintf("UNKNOWN ForageType '%v'", int(s))
+}
+
+// GoString implements GoStringer
+func (s SpatialPDFType) GoString() string {
+	return s.String()
+}
+
+// MarshalText implements TextMarshaler
+func (s SpatialPDFType) MarshalText() ([]byte, error) {
+	return miscutils.MarshalTextForString(s.String())
+}
+
+// MarshalJSON implements RawMessage
+func (s SpatialPDFType) MarshalJSON() ([]byte, error) {
+	return miscutils.MarshalJSONForString(s.String())
+}
+
+// ParseSpatialPDFType gets the SpatialPDFType based on the number
+func ParseSpatialPDFType(x int) SpatialPDFType {
+	if x >= 0 && SpatialPDFType(x) < spatialPDFTypeEnd {
+		return SpatialPDFType(x)
+	}
+	log.Printf("Unknown SpatialPDFType specified: '%v'\nUse --help. Defaulting to %v", x, Uniform)
+	return Uniform
+}
+
+// HelpSpatialPDFType returns a help string for SpatialPDFType
+func HelpSpatialPDFType() string {
+	help := "Set x,y prob. distribution of the disaster's epicentre (more post MVP)\n"
+
+	for i := 0; i < int(spatialPDFTypeEnd); i++ {
+		help += fmt.Sprintf("%v: %v\n", i, SpatialPDFType(i))
+	}
+
+	return help
+}

--- a/internal/server/helper.go
+++ b/internal/server/helper.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
-	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/pkg/errors"
@@ -16,13 +15,14 @@ type clientInfoUpdateResult struct {
 
 func getClientInfosAndMapFromRegisteredClients(
 	registeredClients map[shared.ClientID]baseclient.Client,
+	initialResources shared.Resources,
 ) (map[shared.ClientID]gamestate.ClientInfo, map[shared.ClientID]baseclient.Client) {
 	clientInfos := map[shared.ClientID]gamestate.ClientInfo{}
 	clientMap := map[shared.ClientID]baseclient.Client{}
 
 	for id, c := range registeredClients {
 		clientInfos[id] = gamestate.ClientInfo{
-			Resources:  config.GameConfig().InitialResources,
+			Resources:  initialResources,
 			LifeStatus: shared.Alive,
 		}
 		clientMap[id] = c

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,37 +24,44 @@ type Server interface {
 type SOMASServer struct {
 	gameState gamestate.GameState
 
+	gameConfig config.Config
+
 	// ClientMap maps from the ClientID to the Client object.
 	// We don't store this in gameState--gameState is shared to clients and should
 	// not contain pointers to other clients!
 	clientMap map[shared.ClientID]baseclient.Client
 }
 
-// SOMASServerFactory returns an instance of the main server we use.
-func SOMASServerFactory() Server {
-	clientInfos, clientMap := getClientInfosAndMapFromRegisteredClients(baseclient.RegisteredClients)
-	return createSOMASServer(clientInfos, clientMap)
+// NewSOMASServer returns an instance of the main server we use.
+func NewSOMASServer(gameConfig config.Config) Server {
+	clientInfos, clientMap := getClientInfosAndMapFromRegisteredClients(
+		baseclient.RegisteredClients,
+		gameConfig.InitialResources,
+	)
+	return createSOMASServer(clientInfos, clientMap, gameConfig)
 }
 
 // createSOMASServer creates the main server given initial data about the
 // clients. Extracted from SOMASServerFactory for testing purposes.
 func createSOMASServer(
 	clientInfos map[shared.ClientID]gamestate.ClientInfo,
-	clientMap map[shared.ClientID]baseclient.Client) Server {
-
+	clientMap map[shared.ClientID]baseclient.Client,
+	gameConfig config.Config,
+) Server {
 	clientIDs := make([]shared.ClientID, 0, len(clientMap))
 	for k := range clientMap {
 		clientIDs = append(clientIDs, k)
 	}
 
 	server := &SOMASServer{
-		clientMap: clientMap,
+		clientMap:  clientMap,
+		gameConfig: gameConfig,
 		gameState: gamestate.GameState{
 			Season:         1,
 			Turn:           1,
 			ClientInfos:    clientInfos,
-			Environment:    disasters.InitEnvironment(clientIDs),
-			DeerPopulation: foraging.CreateDeerPopulationModel(),
+			Environment:    disasters.InitEnvironment(clientIDs, gameConfig.DisasterConfig),
+			DeerPopulation: foraging.CreateDeerPopulationModel(gameConfig.ForagingConfig),
 			IIGOHistory:    []shared.Accountability{},
 		},
 	}
@@ -74,7 +81,7 @@ func createSOMASServer(
 func (s *SOMASServer) EntryPoint() ([]gamestate.GameState, error) {
 	states := []gamestate.GameState{s.gameState.Copy()}
 
-	for !s.gameOver(config.GameConfig().MaxTurns, config.GameConfig().MaxSeasons) {
+	for !s.gameOver(s.gameConfig.MaxTurns, s.gameConfig.MaxSeasons) {
 		if err := s.runTurn(); err != nil {
 			return states, err
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/SOMAS2020/SOMAS2020/pkg/testutils"
@@ -89,7 +90,7 @@ func TestSOMASServerFactoryInitialisesClients(t *testing.T) {
 		clientMap[k] = v
 	}
 
-	createSOMASServer(clientInfos, clientMap)
+	createSOMASServer(clientInfos, clientMap, config.Config{})
 
 	for clientID, client := range clientPtrsMap {
 		if !client.initialiseCalled {

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/pkg/errors"
 )
@@ -54,7 +53,6 @@ func (s *SOMASServer) runOrgs() error {
 	return nil
 }
 
-
 // endOfTurn performs end of turn updates
 func (s *SOMASServer) endOfTurn() error {
 	s.logf("start endOfTurn")
@@ -81,7 +79,7 @@ func (s *SOMASServer) endOfTurn() error {
 	s.incrementTurnAndSeason(disasterHappened)
 
 	// deduct cost of living
-	s.deductCostOfLiving(config.GameConfig().CostOfLiving)
+	s.deductCostOfLiving(s.gameConfig.CostOfLiving)
 
 	err = s.updateIslandLivingStatus()
 	if err != nil {
@@ -149,7 +147,7 @@ func (s *SOMASServer) updateIslandLivingStatus() error {
 	nonDeadClients := getNonDeadClientIDs(s.gameState.ClientInfos)
 	for _, id := range nonDeadClients {
 		ci, err := updateIslandLivingStatusForClient(s.gameState.ClientInfos[id],
-			config.GameConfig().MinimumResourceThreshold, config.GameConfig().MaxCriticalConsecutiveTurns)
+			s.gameConfig.MinimumResourceThreshold, s.gameConfig.MaxCriticalConsecutiveTurns)
 		if err != nil {
 			return errors.Errorf("Failed to update island living status for '%v': %v", id, err)
 		}

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -63,32 +63,37 @@ func TestDeductCostOfLiving(t *testing.T) {
 }
 
 func TestUpdateIslandLivingStatus(t *testing.T) {
+	const minimumResourceThreshold = 42
+
 	// this does not test for updateIslandLivingStatusForClient
 	// those are covered in TestUpdateIslandLivingStatusForClient
 	clientInfos := map[shared.ClientID]gamestate.ClientInfo{
 		shared.Team1: {
 			LifeStatus: shared.Alive,
-			Resources:  config.GameConfig().MinimumResourceThreshold - 1,
+			Resources:  minimumResourceThreshold - 1,
 		},
 		shared.Team2: {
 			LifeStatus: shared.Critical,
-			Resources:  config.GameConfig().MinimumResourceThreshold,
+			Resources:  minimumResourceThreshold,
 		},
 	}
 	wantClientInfos := map[shared.ClientID]gamestate.ClientInfo{
 		shared.Team1: {
 			LifeStatus: shared.Critical,
-			Resources:  config.GameConfig().MinimumResourceThreshold - 1,
+			Resources:  minimumResourceThreshold - 1,
 		},
 		shared.Team2: {
 			LifeStatus: shared.Alive,
-			Resources:  config.GameConfig().MinimumResourceThreshold,
+			Resources:  minimumResourceThreshold,
 		},
 	}
 
 	s := SOMASServer{
 		gameState: gamestate.GameState{
 			ClientInfos: clientInfos,
+		},
+		gameConfig: config.Config{
+			MinimumResourceThreshold: minimumResourceThreshold,
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -58,13 +58,14 @@ func initLogger() {
 }
 
 func main() {
-	s := server.SOMASServerFactory()
+	gameConfig := parseConfig()
+	s := server.NewSOMASServer(gameConfig)
 	if gameStates, err := s.EntryPoint(); err != nil {
 		log.Printf("Run failed with: %+v", err)
 		os.Exit(1)
 	} else {
 		fmt.Printf("===== GAME CONFIGURATION =====\n")
-		fmt.Printf("%#v\n", config.GameConfig())
+		fmt.Printf("%#v\n", gameConfig)
 		for _, st := range gameStates {
 			fmt.Printf("===== START OF TURN %v (END OF TURN %v) =====\n", st.Turn, st.Turn-1)
 			fmt.Printf("%#v\n", st)
@@ -72,7 +73,7 @@ func main() {
 
 		outputJSON(output{
 			GameStates: gameStates,
-			Config:     config.GameConfig(),
+			Config:     gameConfig,
 			GitInfo:    getGitInfo(),
 		})
 	}

--- a/params.go
+++ b/params.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+)
+
+var (
+	// config.Config
+	maxSeasons = flag.Uint(
+		"maxSeasons",
+		100,
+		"The maximum number of 1-indexed seasons to run the game.",
+	)
+	maxTurns = flag.Uint(
+		"maxTurns",
+		100,
+		"The maximum numbers of 1-indexed turns to run the game.",
+	)
+	initialResources = flag.Float64(
+		"initialResources",
+		100,
+		"The default number of resources at the start of the game.",
+	)
+	costOfLiving = flag.Float64(
+		"costOfLiving",
+		10,
+		"Subtracted from an islands pool before the next turn.\n"+
+			"This is the simulation-level equivalent to using resources to stay \n"+
+			"alive (e.g. food consumed). These resources are permanently consumed and do \n"+
+			" NOT go into the common pool. Note: this is NOT the same as the tax",
+	)
+	minimumResourceThreshold = flag.Float64(
+		"minimumResourceThreshold",
+		5,
+		"The minimum resources required for an island to not be in Critical state.",
+	)
+	maxCriticalConsecutiveTurns = flag.Uint(
+		"maxCriticalConsecutiveTurns",
+		3,
+		"The maximum consecutive turns an island can be in the critical state.",
+	)
+	// config.ForagingConfig
+	foragingMaxDeerPerHunt = flag.Uint(
+		"foragingMaxDeerPerHunt",
+		4,
+		"Max possible number of deer on a single hunt (regardless of number of participants).",
+	)
+	foragingIncrementalInputDecay = flag.Float64(
+		"foragingIncrementalInputDecay",
+		0.8,
+		"Determines decay of incremental input cost of hunting more deer.",
+	)
+	foragingBernoulliProb = flag.Float64(
+		"foragingBernoulliProb",
+		0.95,
+		"`p` param in D variable (see foraging README). Controls prob of catching a deer or not.",
+	)
+	foragingExponentialRate = flag.Float64(
+		"foragingExponentialRate",
+		1,
+		"`lambda` param in W variable (see foraging README). Controls distribution of deer sizes.",
+	)
+	foragingMaxDeerPopulation = flag.Uint(
+		"maxDeerPopulation",
+		12,
+		"Max possible deer population. Reserved for post-MVP functionality.",
+	)
+	foragingDeerGrowthCoefficient = flag.Float64(
+		"foragingDeerGrowthCoefficient",
+		0.4,
+		"Scaling parameter used in the population model. Larger coeff => deer pop. regenerates faster.",
+	)
+	// config.DisasterConfig
+	disasterXMin = flag.Float64(
+		"disasterXMin",
+		0,
+		"Min x bound of archipelago (bounds for possible disaster).",
+	)
+	disasterXMax = flag.Float64(
+		"disasterXMax",
+		10,
+		"Max x bound of archipelago (bounds for possible disaster).",
+	)
+	disasterYMin = flag.Float64(
+		"disasterYMin",
+		0,
+		"Min y bound of archipelago (bounds for possible disaster).",
+	)
+	disasterYMax = flag.Float64(
+		"disasterYMax",
+		10,
+		"Max y bound of archipelago (bounds for possible disaster).",
+	)
+	disasterGlobalProb = flag.Float64(
+		"disasterGlobalProb",
+		0.1,
+		"Bernoulli 'p' param. Chance of a disaster occurring.",
+	)
+	disasterSpatialPDFType = flag.Int(
+		"disasterSpatialPDFType",
+		0,
+		shared.HelpSpatialPDFType(),
+	)
+	disasterMagnitudeLambda = flag.Float64(
+		"disasterMagnitudeLambda",
+		1,
+		"Exponential rate param for disaster magnitude",
+	)
+)
+
+func parseConfig() config.Config {
+	flag.Parse()
+	foragingConf := config.ForagingConfig{
+		MaxDeerPerHunt:        *foragingMaxDeerPerHunt,
+		IncrementalInputDecay: *foragingIncrementalInputDecay,
+		BernoulliProb:         *foragingBernoulliProb,
+		ExponentialRate:       *foragingExponentialRate,
+
+		MaxDeerPopulation:     *foragingMaxDeerPopulation,
+		DeerGrowthCoefficient: *foragingDeerGrowthCoefficient,
+	}
+	disasterConf := config.DisasterConfig{
+		XMin:            *disasterXMin,
+		XMax:            *disasterXMax, // chosen quite arbitrarily for now
+		YMin:            *disasterYMin,
+		YMax:            *disasterYMax,
+		GlobalProb:      *disasterGlobalProb,
+		SpatialPDFType:  shared.ParseSpatialPDFType(*disasterSpatialPDFType),
+		MagnitudeLambda: *disasterMagnitudeLambda,
+	}
+	return config.Config{
+		MaxSeasons:                  *maxSeasons,
+		MaxTurns:                    *maxTurns,
+		InitialResources:            shared.Resources(*initialResources),
+		CostOfLiving:                shared.Resources(*costOfLiving),
+		MinimumResourceThreshold:    shared.Resources(*minimumResourceThreshold),
+		MaxCriticalConsecutiveTurns: *maxCriticalConsecutiveTurns,
+		ForagingConfig:              foragingConf,
+		DisasterConfig:              disasterConf,
+	}
+}


### PR DESCRIPTION
# Summary

- Allow overriding of config via CLI instead of just editing config.go file.
- `gameConfig` now passed into `NewSOMASServer` (previously known as SOMASSeverFactory), and stored as a variable.
- Fixed code that depended on global config as well to take in gameConfig from the server.

## Additional Information

Fixed typos here and there, clarified some docs.

## Test Plan

- `go run . --help`
```
Usage of C:\Users\lhlee\Documents\SOMAS\SOMAS2020\SOMAS2020.exe:
  -costOfLiving float
        Subtracted from an islands pool before the next turn.
        This is the simulation-level equivalent to using resources to stay
        alive (e.g. food consumed). These resources are permanently consumed and do
         NOT go into the common pool. Note: this is NOT the same as the tax (default 10)
  -disasterGlobalProb float
        Bernoulli 'p' param. Chance of a disaster occurring. (default 0.1)
  -disasterMagnitudeLambda float
        Exponential rate param for disaster magnitude (default 1)
  -disasterSpatialPDFType int
        Set x,y prob. distribution of the disaster's epicentre (more post MVP)
        0: Uniform

  -disasterXMax float
        Max x bound of archipelago (bounds for possible disaster). (default 10)
  -disasterXMin float
        Min x bound of archipelago (bounds for possible disaster).
  -disasterYMax float
        Max y bound of archipelago (bounds for possible disaster). (default 10)
  -disasterYMin float
        Min y bound of archipelago (bounds for possible disaster).
  -foragingBernoulliProb p
        p param in D variable (see foraging README). Controls prob of catching a deer or not. (default 0.95)
  -foragingDeerGrowthCoefficient float
        Scaling parameter used in the population model. Larger coeff => deer pop. regenerates faster. (default 0.4)
  -foragingExponentialRate lambda
        lambda param in W variable (see foraging README). Controls distribution of deer sizes. (default 1)
  -foragingIncrementalInputDecay float
        Determines decay of incremental input cost of hunting more deer. (default 0.8)
  -foragingMaxDeerPerHunt uint
        Max possible number of deer on a single hunt (regardless of number of participants). (default 4)
  -initialResources float
        The default number of resources at the start of the game. (default 100)
  -maxCriticalConsecutiveTurns uint
        The maximum consecutive turns an island can be in the critical state. (default 3)
  -maxDeerPopulation uint
        Max possible deer population. Reserved for post-MVP functionality. (default 12)
  -maxSeasons uint
        The maximum number of 1-indexed seasons to run the game. (default 100)
  -maxTurns uint
        The maximum numbers of 1-indexed turns to run the game. (default 100)
  -minimumResourceThreshold float
        The minimum resources required for an island to not be in Critical state. (default 5)
```

- `go run . -maxTurns 0`
```
go run . -maxTurns 0
2020/12/27 14:22:26 [SERVER]: Max turns '0' reached or exceeded
===== GAME CONFIGURATION =====
config.Config{MaxSeasons:0x64, MaxTurns:0x0, InitialResources:100, CostOfLiving:10, MinimumResourceThreshold:5, MaxCriticalConsecutiveTurns:0x3, ForagingConfig:config.ForagingConfig{MaxDeerPerHunt:0x4, IncrementalInputDecay:0.8, BernoulliProb:0.95, ExponentialRate:1, MaxDeerPopulation:0xc, DeerGrowthCoefficient:0.4}, DisasterConfig:config.DisasterConfig{XMin:0, XMax:10, YMin:0, YMax:10, GlobalProb:0.1, SpatialPDFType:Uniform, MagnitudeLambda:1}}
===== START OF TURN 1 (END OF TURN 0) =====
gamestate.GameState{Season:0x1, Turn:0x1, CommonPool:0, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}, Environment:disasters.Environment{Geography:disasters.ArchipelagoGeography{Islands:map[shared.ClientID]disasters.IslandLocationInfo{Team1:disasters.IslandLocationInfo{ID:Team1, X:5, Y:0}, Team2:disasters.IslandLocationInfo{ID:Team2, X:0, Y:0}, Team3:disasters.IslandLocationInfo{ID:Team3, X:1, Y:0}, Team4:disasters.IslandLocationInfo{ID:Team4, X:2, Y:0}, Team5:disasters.IslandLocationInfo{ID:Team5, X:3, Y:0}, Team6:disasters.IslandLocationInfo{ID:Team6, X:4, Y:0}}, XMin:0, XMax:10, YMin:0, YMax:0}, DisasterParams:disasters.disasterParameters{globalProb:0.1, spatialPDF:0, magnitudeLambda:1}, LastDisasterReport:disasters.DisasterReport{Magnitude:0, X:0, Y:0}}, DeerPopulation:foraging.DeerPopulationModel{deProblem:simulation.ODEProblem{YPrime:(simulation.ypFunc)(0xef5bc0), T0:0, Y0:12, DtStep:0.1}, Population:12, T:0}, IIGOHistory:(*[]shared.Accountability)(0x1088310)}
2020/12/27 14:22:27 Writing JSON output to 'C:/Users/lhlee/Documents/SOMAS/SOMAS2020/output/output.json'
2020/12/27 14:22:27 Finished writing JSON output to 'C:/Users/lhlee/Documents/SOMAS/SOMAS2020/output/output.json'
```

- `go run . -maxTurns 1`
```
2020/12/27 14:22:03 [SERVER]: start runTurn
2020/12/27 14:22:03 [SERVER]: TURN: 1, Season: 1
2020/12/27 14:22:03 [SERVER]: start runOrgs
2020/12/27 14:22:03 [SERVER]: start runIIGO
2020/12/27 14:22:03 [SERVER]: finish runIIGO
2020/12/27 14:22:03 [SERVER]: start runIIFO
2020/12/27 14:22:03 [SERVER]: start runPredictionSession
2020/12/27 14:22:03 [Team5]: Final Prediction: [{1.2 1.2 1.2 1 100}]
2020/12/27 14:22:03 [Team6]: Final Prediction: [{1.2 1.2 1.2 1 100}]
2020/12/27 14:22:03 [Team1]: Final Prediction: [{1.2 1.2 1.2 1 100}]
2020/12/27 14:22:03 [Team2]: Final Prediction: [{1.2 1.2 1.2 1 100}]
2020/12/27 14:22:03 [Team3]: Final Prediction: [{1.2 1.2 1.2 1 100}]
2020/12/27 14:22:03 [Team4]: Final Prediction: [{1.2 1.2 1.2 1 100}]
2020/12/27 14:22:03 [SERVER]: finish runPredictionSession
2020/12/27 14:22:03 [SERVER]: Run Forage Predictions
2020/12/27 14:22:03 [SERVER]: Getting Forage Information
2020/12/27 14:22:03 [SERVER]: Distributing Forage Information
2020/12/27 14:22:03 [SERVER]: Finish Running Forage Predictions
2020/12/27 14:22:03 [SERVER]: finish runIIFO
2020/12/27 14:22:03 [SERVER]: start runIITO
2020/12/27 14:22:03 [SERVER]: start runGiftSession
2020/12/27 14:22:03 [SERVER]: Gifts from Team6: map[Team1:{Team1 Team6 0 0 0} Team2:{Team2 Team6 0 0 0} Team3:{Team3 Team6 0 0 0} Team4:{Team4 Team6 0 0 0} Team5:{Team5 Team6 0 0 0}]
2020/12/27 14:22:03 [SERVER]: Gifts from Team1: map[Team2:{Team2 Team1 0 0 0} Team3:{Team3 Team1 0 0 0} Team4:{Team4 Team1 0 0 0} Team5:{Team5 Team1 0 0 0} Team6:{Team6 Team1 0 0 0}]
2020/12/27 14:22:03 [SERVER]: Gifts from Team2: map[Team1:{Team1 Team2 0 0 0} Team3:{Team3 Team2 0 0 0} Team4:{Team4 Team2 0 0 0} Team5:{Team5 Team2 0 0 0} Team6:{Team6 Team2 0 0 0}]
2020/12/27 14:22:03 [SERVER]: Gifts from Team3: map[Team1:{Team1 Team3 0 0 0} Team2:{Team2 Team3 0 0 0} Team4:{Team4 Team3 0 0 0} Team5:{Team5 Team3 0 0 0} Team6:{Team6 Team3 0 0 0}]
2020/12/27 14:22:03 [SERVER]: Gifts from Team4: map[Team1:{Team1 Team4 0 0 0} Team2:{Team2 Team4 0 0 0} Team3:{Team3 Team4 0 0 0} Team5:{Team5 Team4 0 0 0} Team6:{Team6 Team4 0 0 0}]
2020/12/27 14:22:03 [SERVER]: Gifts from Team5: map[Team1:{Team1 Team5 0 0 0} Team2:{Team2 Team5 0 0 0} Team3:{Team3 Team5 0 0 0} Team4:{Team4 Team5 0 0 0} Team6:{Team6 Team5 0 0 0}]
2020/12/27 14:22:03 [SERVER]: finish runGiftSession
2020/12/27 14:22:03 [SERVER]: finish runIITO
2020/12/27 14:22:03 [SERVER]: finish runOrgs
2020/12/27 14:22:03 [SERVER]: start endOfTurn
2020/12/27 14:22:03 [SERVER]: start runOrgsEndOfTurn
2020/12/27 14:22:03 [SERVER]: start runIIGOEndOfTurn
2020/12/27 14:22:03 [SERVER]: Took 0 from Team4 (reason: tax)
2020/12/27 14:22:03 [SERVER]: Took 0 from Team5 (reason: tax)
2020/12/27 14:22:03 [SERVER]: Took 0 from Team6 (reason: tax)
2020/12/27 14:22:03 [SERVER]: Took 0 from Team1 (reason: tax)
2020/12/27 14:22:03 [SERVER]: Took 0 from Team2 (reason: tax)
2020/12/27 14:22:03 [SERVER]: Took 0 from Team3 (reason: tax)
2020/12/27 14:22:03 [SERVER]: finish runIIGOEndOfTurn
2020/12/27 14:22:03 [SERVER]: start runIIFOEndOfTurn
2020/12/27 14:22:03 [SERVER]: finish runIIFOEndOfTurn
2020/12/27 14:22:03 [SERVER]: start runIITOEndOfTurn
2020/12/27 14:22:03 [SERVER]: finish runIITOEndOfTurn
2020/12/27 14:22:03 [SERVER]: finish runOrgsEndOfTurn
2020/12/27 14:22:03 [SERVER]: start runForage
2020/12/27 14:22:03 [SERVER]: Took 3.322800266092452 from Team1 (reason: deer hunt participation)
2020/12/27 14:22:03 [SERVER]: Took 2.188570935934901 from Team2 (reason: deer hunt participation)
2020/12/27 14:22:03 [SERVER]: Took 2.1231874853563286 from Team3 (reason: deer hunt participation)
2020/12/27 14:22:03 [SERVER]: Took 3.434115364335547 from Team4 (reason: deer hunt participation)
2020/12/27 14:22:03 [SERVER]: Took 3.023301439898098 from Team5 (reason: deer hunt participation)
2020/12/27 14:22:03 [SERVER]: Took 4.702545440225062 from Team6 (reason: deer hunt participation)
2020/12/27 14:22:03 [SERVER]: start runDeerHunt
2020/12/27 14:22:03 [SERVER]: Gave 1.0195611712568775 to Team3 (reason: Deer hunt return)
2020/12/27 14:22:03 [SERVER]: Gave 1.6490727772472609 to Team4 (reason: Deer hunt return)
2020/12/27 14:22:03 [SERVER]: Gave 1.4517986651601762 to Team5 (reason: Deer hunt return)
2020/12/27 14:22:03 [SERVER]: Gave 2.2581768072732866 to Team6 (reason: Deer hunt return)
2020/12/27 14:22:03 [SERVER]: Gave 1.5956189241485284 to Team1 (reason: Deer hunt return)
2020/12/27 14:22:03 [SERVER]: Gave 1.0509585056479651 to Team2 (reason: Deer hunt return)
2020/12/27 14:22:03 [SERVER]: Hunt generated a return of 9.025 from input of 18.795
2020/12/27 14:22:03 [SERVER]: finish runDeerHunt
2020/12/27 14:22:03 [SERVER]: finish runForage
2020/12/27 14:22:03 [SERVER]: start probeDisaster
2020/12/27 14:22:03 [SERVER]: No disaster reported.
2020/12/27 14:22:03 [SERVER]: finish probeDisaster
2020/12/27 14:22:03 [SERVER]: start incrementTurnAndSeason
2020/12/27 14:22:03 [SERVER]: finish incrementTurnAndSeason
2020/12/27 14:22:03 [SERVER]: start deductCostOfLiving
2020/12/27 14:22:03 [SERVER]: finish deductCostOfLiving
2020/12/27 14:22:03 [SERVER]: start updateIslandLivingStatus
2020/12/27 14:22:03 [SERVER]: finish updateIslandLivingStatus
2020/12/27 14:22:03 [SERVER]: finish endOfTurn
2020/12/27 14:22:03 [SERVER]: finish runTurn
2020/12/27 14:22:03 [SERVER]: Max turns '1' reached or exceeded
===== GAME CONFIGURATION =====
config.Config{MaxSeasons:0x64, MaxTurns:0x1, InitialResources:100, CostOfLiving:10, MinimumResourceThreshold:5, MaxCriticalConsecutiveTurns:0x3, ForagingConfig:config.ForagingConfig{MaxDeerPerHunt:0x4, IncrementalInputDecay:0.8, BernoulliProb:0.95, ExponentialRate:1, MaxDeerPopulation:0xc, DeerGrowthCoefficient:0.4}, DisasterConfig:config.DisasterConfig{XMin:0, XMax:10, YMin:0, YMax:10, GlobalProb:0.1, SpatialPDFType:Uniform, MagnitudeLambda:1}}
===== START OF TURN 1 (END OF TURN 0) =====
gamestate.GameState{Season:0x1, Turn:0x1, CommonPool:0, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:100, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}, Environment:disasters.Environment{Geography:disasters.ArchipelagoGeography{Islands:map[shared.ClientID]disasters.IslandLocationInfo{Team1:disasters.IslandLocationInfo{ID:Team1, X:1, Y:0}, Team2:disasters.IslandLocationInfo{ID:Team2, X:2, Y:0}, Team3:disasters.IslandLocationInfo{ID:Team3, X:3, Y:0}, Team4:disasters.IslandLocationInfo{ID:Team4, X:4, Y:0}, Team5:disasters.IslandLocationInfo{ID:Team5, X:5, Y:0}, Team6:disasters.IslandLocationInfo{ID:Team6, X:0, Y:0}}, XMin:0, XMax:10, YMin:0, YMax:0}, DisasterParams:disasters.disasterParameters{globalProb:0.1, spatialPDF:0, magnitudeLambda:1}, LastDisasterReport:disasters.DisasterReport{Magnitude:0, X:0, Y:0}}, DeerPopulation:foraging.DeerPopulationModel{deProblem:simulation.ODEProblem{YPrime:(simulation.ypFunc)(0x255bc0), T0:0, Y0:12, DtStep:0.1}, Population:12, T:0}, IIGOHistory:(*[]shared.Accountability)(0x3e8310)}
===== START OF TURN 2 (END OF TURN 1) =====
gamestate.GameState{Season:0x1, Turn:0x2, CommonPool:0, ClientInfos:map[shared.ClientID]gamestate.ClientInfo{Team1:gamestate.ClientInfo{Resources:88.27281865805607, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team2:gamestate.ClientInfo{Resources:88.86238756971306, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team3:gamestate.ClientInfo{Resources:88.89637368590056, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team4:gamestate.ClientInfo{Resources:88.2149574129117, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team5:gamestate.ClientInfo{Resources:88.42849722526209, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}, Team6:gamestate.ClientInfo{Resources:87.55563136704822, LifeStatus:Alive, CriticalConsecutiveTurnsCounter:0x0}}, Environment:disasters.Environment{Geography:disasters.ArchipelagoGeography{Islands:map[shared.ClientID]disasters.IslandLocationInfo{Team1:disasters.IslandLocationInfo{ID:Team1, X:1, Y:0}, Team2:disasters.IslandLocationInfo{ID:Team2, X:2, Y:0}, Team3:disasters.IslandLocationInfo{ID:Team3, X:3, Y:0}, Team4:disasters.IslandLocationInfo{ID:Team4, X:4, Y:0}, Team5:disasters.IslandLocationInfo{ID:Team5, X:5, Y:0}, Team6:disasters.IslandLocationInfo{ID:Team6, X:0, Y:0}}, XMin:0, XMax:10, YMin:0, YMax:0}, DisasterParams:disasters.disasterParameters{globalProb:0.1, spatialPDF:0, magnitudeLambda:1}, LastDisasterReport:disasters.DisasterReport{Magnitude:0, X:-1, Y:-1}}, DeerPopulation:foraging.DeerPopulationModel{deProblem:simulation.ODEProblem{YPrime:(simulation.ypFunc)(0x255bc0), T0:0, Y0:12, DtStep:0.1}, Population:12, T:0}, IIGOHistory:(*[]shared.Accountability)(0x3e8310)}
2020/12/27 14:22:03 Writing JSON output to 'C:/Users/lhlee/Documents/SOMAS/SOMAS2020/output/output.json'
2020/12/27 14:22:03 Finished writing JSON output to 'C:/Users/lhlee/Documents/SOMAS/SOMAS2020/output/output.json'
```
