### PR TITLE
[INFRA/CORE] Add necessary Stringer functions for iotas

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -38,6 +38,8 @@ s4 := S{name: "pittson"} // OK if `pittson`'s age is 0
 
 7. Use the superior `errors.Errorf` to create your errors so that we have a stack trace.
 
+8. If you define a new `iota`, please implement the `String()`, `GoString()`, `MarshalText()`, and `MarshalJSON()` functions. See [`#150`](https://github.com/SOMAS2020/SOMAS2020/pull/150).
+
 ## Repo
 
 1. Each team will work off a fork of the main repo. Your team is responsible for all development happening in the fork, and are responsible to keep your own fork up-to-date, as well as to pull in changes to the main repo periodically. (Remember to give your teammates _write access_ to the fork!)

--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/rules"
+	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/roles"
@@ -115,13 +116,36 @@ func (c *BaseClient) Logf(format string, a ...interface{}) {
 	log.Printf("[%v]: %v", c.id, fmt.Sprintf(format, a...))
 }
 
-type Role = int
+type Role int
 
 const (
 	President Role = iota
 	Speaker
 	Judge
 )
+
+func (r Role) String() string {
+	strs := [...]string{"President", "Speaker", "Judge"}
+	if r >= 0 && int(r) < len(strs) {
+		return strs[r]
+	}
+	return fmt.Sprintf("UNKNOWN Role '%v'", int(r))
+}
+
+// GoString implements GoStringer
+func (r Role) GoString() string {
+	return r.String()
+}
+
+// MarshalText implements TextMarshaler
+func (r Role) MarshalText() ([]byte, error) {
+	return miscutils.MarshalTextForString(r.String())
+}
+
+// MarshalJSON implements RawMessage
+func (r Role) MarshalJSON() ([]byte, error) {
+	return miscutils.MarshalJSONForString(r.String())
+}
 
 // GetVoteForRule returns the client's vote in favour of or against a rule.
 func (c *BaseClient) GetVoteForRule(ruleName string) bool {

--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -116,6 +116,7 @@ func (c *BaseClient) Logf(format string, a ...interface{}) {
 	log.Printf("[%v]: %v", c.id, fmt.Sprintf(format, a...))
 }
 
+// Role provides enumerated type for IIGO roles (President, Speaker and Judge)
 type Role int
 
 const (

--- a/internal/common/rules/globalvariablecache.go
+++ b/internal/common/rules/globalvariablecache.go
@@ -1,6 +1,11 @@
 package rules
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+
+	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
+	"github.com/pkg/errors"
+)
 
 type VariableValuePair struct {
 	VariableName VariableFieldName
@@ -57,3 +62,43 @@ const (
 	IslandAllocation
 	TestVariable
 )
+
+func (v VariableFieldName) String() string {
+	strs := [...]string{
+		"NumberOfIslandsContributingToCommonPool",
+		"NumberOfFailedForages",
+		"NumberOfBrokenAgreements",
+		"MaxSeverityOfSanctions",
+		"NumberOfIslandsAlive",
+		"NumberOfBallotsCast",
+		"NumberOfAllocationsSent",
+		"IslandsAlive",
+		"SpeakerSalary",
+		"JudgeSalary",
+		"PresidentSalary",
+		"ExpectedTaxContribution",
+		"ExpectedAllocation",
+		"IslandTaxContribution",
+		"IslandAllocation",
+		"TestVariable",
+	}
+	if v >= 0 && int(v) < len(strs) {
+		return strs[v]
+	}
+	return fmt.Sprintf("UNKNOWN VariableFieldName '%v'", int(v))
+}
+
+// GoString implements GoStringer
+func (v VariableFieldName) GoString() string {
+	return v.String()
+}
+
+// MarshalText implements TextMarshaler
+func (v VariableFieldName) MarshalText() ([]byte, error) {
+	return miscutils.MarshalTextForString(v.String())
+}
+
+// MarshalJSON implements RawMessage
+func (v VariableFieldName) MarshalJSON() ([]byte, error) {
+	return miscutils.MarshalJSONForString(v.String())
+}

--- a/internal/common/shared/forage.go
+++ b/internal/common/shared/forage.go
@@ -16,15 +16,6 @@ const (
 	FishForageType
 )
 
-// ForageDecision is used to represent a foraging decision made by agents
-type ForageDecision struct {
-	Type         ForageType
-	Contribution Resources
-}
-
-// ForagingDecisionsDict is a map of clients' foraging decisions
-type ForagingDecisionsDict = map[ClientID]ForageDecision
-
 func (ft ForageType) String() string {
 	strings := [...]string{"DeerForageType", "FishForageType"}
 	if ft >= 0 && int(ft) < len(strings) {
@@ -47,6 +38,15 @@ func (ft ForageType) MarshalText() ([]byte, error) {
 func (ft ForageType) MarshalJSON() ([]byte, error) {
 	return miscutils.MarshalJSONForString(ft.String())
 }
+
+// ForageDecision is used to represent a foraging decision made by agents
+type ForageDecision struct {
+	Type         ForageType
+	Contribution Resources
+}
+
+// ForagingDecisionsDict is a map of clients' foraging decisions
+type ForagingDecisionsDict = map[ClientID]ForageDecision
 
 // ForageShareInfo is used to represent the forage informations shared by agents
 type ForageShareInfo struct {

--- a/internal/common/shared/iigocommunications.go
+++ b/internal/common/shared/iigocommunications.go
@@ -1,14 +1,46 @@
 package shared
 
-import "github.com/SOMAS2020/SOMAS2020/internal/common/rules"
+import (
+	"fmt"
 
-type CommunicationContentType = int
+	"github.com/SOMAS2020/SOMAS2020/internal/common/rules"
+	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
+)
+
+type CommunicationContentType int
 
 const (
 	CommunicationInt CommunicationContentType = iota
 	CommunicationString
 	CommunicationBool
 )
+
+func (c CommunicationContentType) String() string {
+	strs := [...]string{
+		"CommunicationInt",
+		"CommunicationString",
+		"CommunicationBool",
+	}
+	if c >= 0 && int(c) < len(strs) {
+		return strs[c]
+	}
+	return fmt.Sprintf("UNKNOWN CommunicationContentType '%v'", int(c))
+}
+
+// GoString implements GoStringer
+func (c CommunicationContentType) GoString() string {
+	return c.String()
+}
+
+// MarshalText implements TextMarshaler
+func (c CommunicationContentType) MarshalText() ([]byte, error) {
+	return miscutils.MarshalTextForString(c.String())
+}
+
+// MarshalJSON implements RawMessage
+func (c CommunicationContentType) MarshalJSON() ([]byte, error) {
+	return miscutils.MarshalJSONForString(c.String())
+}
 
 // CommunicationContent is a general datastructure used for communications
 type CommunicationContent struct {
@@ -33,6 +65,41 @@ const (
 	TaxAmount
 	AllocationAmount
 )
+
+func (c CommunicationFieldName) String() string {
+	strs := [...]string{
+		"BallotID",
+		"PresidentAllocationCheck",
+		"SpeakerID",
+		"RoleConducted",
+		"ResAllocID",
+		"SpeakerBallotCheck",
+		"PresidentID",
+		"RuleName",
+		"RuleVoteResult",
+		"TaxAmount",
+		"AllocationAmount",
+	}
+	if c >= 0 && int(c) < len(strs) {
+		return strs[c]
+	}
+	return fmt.Sprintf("UNKNOWN CommunicationFieldName '%v'", int(c))
+}
+
+// GoString implements GoStringer
+func (c CommunicationFieldName) GoString() string {
+	return c.String()
+}
+
+// MarshalText implements TextMarshaler
+func (c CommunicationFieldName) MarshalText() ([]byte, error) {
+	return miscutils.MarshalTextForString(c.String())
+}
+
+// MarshalJSON implements RawMessage
+func (c CommunicationFieldName) MarshalJSON() ([]byte, error) {
+	return miscutils.MarshalJSONForString(c.String())
+}
 
 type Accountability struct {
 	ClientID ClientID

--- a/internal/common/shared/iigocommunications.go
+++ b/internal/common/shared/iigocommunications.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
 )
 
+// CommunicationContentType provides type union for generic IIGO Inter-Island Communications
 type CommunicationContentType int
 
 const (

--- a/internal/common/voting/election.go
+++ b/internal/common/voting/election.go
@@ -15,6 +15,7 @@ type Election struct {
 	votes         [][]shared.ClientID
 }
 
+// ElectionVotingMethod provides enumerated type for selection of voting system to be used
 type ElectionVotingMethod int
 
 const (

--- a/internal/common/voting/election.go
+++ b/internal/common/voting/election.go
@@ -1,8 +1,11 @@
 package voting
 
 import (
+	"fmt"
+
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
 )
 
 type Election struct {
@@ -12,13 +15,40 @@ type Election struct {
 	votes         [][]shared.ClientID
 }
 
-type ElectionVotingMethod = int
+type ElectionVotingMethod int
 
 const (
 	BordaCount = iota
 	Plurality
 	Majority
 )
+
+func (e ElectionVotingMethod) String() string {
+	strs := [...]string{
+		"BordaCount",
+		"Plurality",
+		"Majority",
+	}
+	if e >= 0 && int(e) < len(strs) {
+		return strs[e]
+	}
+	return fmt.Sprintf("UNKNOWN ElectionVotingMethod '%v'", int(e))
+}
+
+// GoString implements GoStringer
+func (e ElectionVotingMethod) GoString() string {
+	return e.String()
+}
+
+// MarshalText implements TextMarshaler
+func (e ElectionVotingMethod) MarshalText() ([]byte, error) {
+	return miscutils.MarshalTextForString(e.String())
+}
+
+// MarshalJSON implements RawMessage
+func (e ElectionVotingMethod) MarshalJSON() ([]byte, error) {
+	return miscutils.MarshalJSONForString(e.String())
+}
 
 // ProposeMotion sets the role to be voted on
 func (e *Election) ProposeElection(role baseclient.Role, method ElectionVotingMethod) {


### PR DESCRIPTION
# Summary

Add the `String()`, `GoString()`, `MarshalText()`, and `MarshalJSON()` functions for iotas. This is needed to output well-formed strings in JSON & logs.

## Additional Information

- `SpatialPDFType` is left out, this is impl. in #146.
- Not fixing `golint`--these are not caused by my changes.

## Test Plan

Unit tests passed, run succeeded. Logs and output now print actual representative strings instead of bare integers.