### PR TITLE
[INFRA/CORE] Cleanup

### DIFF
--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -16,16 +16,14 @@ import (
 type Client interface {
 	Echo(s string) string
 	GetID() shared.ClientID
-
-	// Initialise is called once on game start. You can keep the value of
-	// ServerReadHandle which can then be used to access the ClientGameState at
-	// any point
 	Initialise(ServerReadHandle)
-
-	// StartOfTurn is called at the beginning of each turn
 	StartOfTurn()
-
 	Logf(format string, a ...interface{})
+
+	GetVoteForRule(ruleName string) bool
+	GetVoteForElection(roleToElect Role) []shared.ClientID
+	ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent)
+	GetCommunications() *map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
 
 	CommonPoolResourceRequest() shared.Resources
 	ResourceReport() shared.Resources
@@ -33,13 +31,13 @@ type Client interface {
 	GetClientPresidentPointer() roles.President
 	GetClientJudgePointer() roles.Judge
 	GetClientSpeakerPointer() roles.Speaker
-	ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent)
-	GetCommunications() *map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
+	TaxTaken(shared.Resources)
 	GetTaxContribution() shared.Resources
 	RequestAllocation() shared.Resources
 
-	// TaxTaken is called on the client after tax has been taken from it
-	TaxTaken(shared.Resources)
+	//Foraging
+	DecideForage() (shared.ForageDecision, error)
+	ForageUpdate(shared.ForageDecision, shared.Resources)
 
 	//IIFO: OPTIONAL
 	MakePrediction() (shared.PredictionInfo, error)
@@ -53,17 +51,9 @@ type Client interface {
 	AcceptGifts(receivedGiftDict shared.GiftDict) (shared.GiftInfoDict, error)
 	UpdateGiftInfo(acceptedGifts map[shared.ClientID]shared.GiftInfoDict) error
 
-	//Foraging
-	DecideForage() (shared.ForageDecision, error)
-	// ForageUpdate is called with the total resources returned to the agent
-	// from the hunt (NOT the profit)
-	ForageUpdate(shared.ForageDecision, shared.Resources)
-
 	//TODO: THESE ARE NOT DONE yet, how do people think we should implement the actual transfer?
 	SendGift(receivingClient shared.ClientID, amount int) error
 	ReceiveGift(sendingClient shared.ClientID, amount int) error
-	GetVoteForRule(ruleName string) bool
-	GetVoteForElection(roleToElect Role) []shared.ClientID
 }
 
 // ServerReadHandle is a read-only handle to the game server, used for client to get up-to-date gamestate
@@ -74,7 +64,6 @@ type ServerReadHandle interface {
 var ourPredictionInfo shared.PredictionInfo
 
 // NewClient produces a new client with the BaseClient already implemented.
-// BASE: Do not overwrite in team client.
 func NewClient(id shared.ClientID) Client {
 	return &BaseClient{id: id, communications: map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent{}}
 }
@@ -83,9 +72,9 @@ func NewClient(id shared.ClientID) Client {
 // All clients should be based off of this BaseClient to ensure that all clients implement the interface,
 // even when new features are added.
 type BaseClient struct {
-	id              shared.ClientID
-	clientGameState gamestate.ClientGameState
-	communications  map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
+	id               shared.ClientID
+	clientGameState  gamestate.ClientGameState
+	communications   map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
 	serverReadHandle ServerReadHandle
 }
 
@@ -119,23 +108,6 @@ func (c *BaseClient) StartOfTurn() {}
 // BASE: Do not overwrite in team client.
 func (c *BaseClient) Logf(format string, a ...interface{}) {
 	log.Printf("[%v]: %v", c.id, fmt.Sprintf(format, a...))
-}
-
-// StartOfTurnUpdate is updates the gamestate of the client at the start of each turn.
-// The gameState is served by the server.
-// OPTIONAL. Base should be able to handle it but feel free to implement your own.
-func (c *BaseClient) StartOfTurnUpdate(gameState gamestate.ClientGameState) {
-	c.Logf("Received start of turn game state update: %#v", gameState)
-	c.clientGameState = gameState
-	// TODO
-}
-
-// GameStateUpdate updates game state mid-turn.
-// The gameState is served by the server.
-// OPTIONAL. Base should be able to handle it but feel free to implement your own.
-func (c *BaseClient) GameStateUpdate(gameState gamestate.ClientGameState) {
-	c.Logf("Received game state update: %#v", gameState)
-	c.clientGameState = gameState
 }
 
 type Role = int

--- a/internal/common/baseclient/baseclient_iigo.go
+++ b/internal/common/baseclient/baseclient_iigo.go
@@ -43,7 +43,7 @@ func (c *BaseClient) GetClientSpeakerPointer() roles.Speaker {
 	return nil
 }
 
-func (c BaseClient) TaxTaken(shared.Resources) {
+func (c *BaseClient) TaxTaken(shared.Resources) {
 	// Just an update. Ignore
 }
 

--- a/internal/server/iigointernal/utilities_test.go
+++ b/internal/server/iigointernal/utilities_test.go
@@ -1,7 +1,6 @@
 package iigointernal
 
 import (
-	"github.com/SOMAS2020/SOMAS2020/pkg/testutils"
 	"reflect"
 	"testing"
 
@@ -55,7 +54,9 @@ func TestWithdrawFromCommonPoolDeductsValue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, withdrawSuccessful := WithdrawFromCommonPool(tc.valueToWithdraw, &tc.fakeGameState)
 			got := tc.fakeGameState.CommonPool
-			testutils.CompareTestIntegers(int(tc.expectedRemainder), int(got), t)
+			if tc.expectedRemainder != got {
+				t.Errorf("remainder: want '%v' got '%v'", tc.expectedRemainder, got)
+			}
 			if tc.expectedResult != withdrawSuccessful {
 				t.Errorf("Expected withdrawalResult to be '%v' got '%v'", tc.expectedResult, withdrawSuccessful)
 			}

--- a/pkg/gitinfo/gitinfo.go
+++ b/pkg/gitinfo/gitinfo.go
@@ -12,7 +12,6 @@ import (
 // GitInfo contains information about the latest config of the repo.
 type GitInfo struct {
 	Hash      string
-	ShortHash string
 	GithubURL string
 }
 
@@ -26,7 +25,6 @@ func GetGitInfo(wd string) (GitInfo, error) {
 	}
 	hash := strings.TrimSpace(string(hashBuf))
 	gitInfo.Hash = hash
-	gitInfo.ShortHash = hash[:7]
 
 	remoteURLBuf, err := sysutils.RunCommandInDir("git", []string{"config", "--get", "remote.origin.url"}, wd)
 	if err != nil {

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -21,10 +21,3 @@ func CompareTestErrors(want error, got error, t *testing.T) {
 		}
 	}
 }
-
-// CompareTestIntegers is used to check wheter an expected int value is equal to what was got
-func CompareTestIntegers(want int, got int, t *testing.T) {
-	if want != got {
-		t.Errorf("Wanted integer '%v' got '%v'", want, got)
-	}
-}

--- a/website/src/containers/AppLayout/Navbar/Navbar.tsx
+++ b/website/src/containers/AppLayout/Navbar/Navbar.tsx
@@ -36,7 +36,7 @@ const AppNavbar = () => {
             </Link>
 
             <a rel="noopener noreferrer" target="_blank" href={outputJSONData.GitInfo.GithubURL} className="lightbluelink">
-                {outputJSONData.GitInfo.ShortHash}
+                {outputJSONData.GitInfo.Hash.substr(0, 7)}
             </a>
 
 


### PR DESCRIPTION
# Summary

- Tidy up `BaseClient` interface to follow sequence of method definitions
- Remove unused `BaseClient` method implementations
- Remove `CompareTestIntegers`
- Remove `ShortHash` from `GitInfo` -- 7 is an arbitrary number chosen by GitHub.


## Test Plan

Unit tests pass.
