### PR TITLE
[INFRA/CORE] Add help details on README.md and fix fConf bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ go build # build step
 ./SOMAS2020 # SOMAS2020.exe if you're on Windows. Use `sudo` on Linux and macOS as Approach 1 if required.
 ```
 
+### Parameters & Help
+```bash
+go run . --help
+```
+
 ### Output
 After running, the `output` directory will contain the output of the program.
 - `output.json`: JSON file containing the game's historic states and configuration.

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -45,7 +45,7 @@ type ForagingConfig struct {
 	ExponentialRate       float64 // `lambda` param in W variable (see README). Controls distribution of deer sizes.
 
 	// Deer Population
-	MaxDeerPopulation     uint    // Max possible deer population. Reserved for post-MVP functionality
+	MaxDeerPopulation     uint    // Max possible deer population.
 	DeerGrowthCoefficient float64 // Scaling parameter used in the population model. Larger coeff => deer pop. regenerates faster
 
 	// TODO: add other pertinent params here (for fishing etc)

--- a/internal/server/forage.go
+++ b/internal/server/forage.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/foraging"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/pkg/errors"
@@ -53,15 +52,7 @@ func (s *SOMASServer) runDeerHunt(contributions map[shared.ClientID]shared.Resou
 	s.logf("start runDeerHunt")
 	defer s.logf("finish runDeerHunt")
 
-	fConf := config.ForagingConfig{
-		MaxDeerPerHunt:        4,
-		IncrementalInputDecay: 0.8,
-		BernoulliProb:         0.95,
-		ExponentialRate:       1,
-
-		MaxDeerPopulation:     12,
-		DeerGrowthCoefficient: 0.4,
-	}
+	fConf := s.gameConfig.ForagingConfig
 
 	hunt, err := foraging.CreateDeerHunt(
 		contributions,

--- a/params.go
+++ b/params.go
@@ -66,7 +66,7 @@ var (
 	foragingMaxDeerPopulation = flag.Uint(
 		"maxDeerPopulation",
 		12,
-		"Max possible deer population. Reserved for post-MVP functionality.",
+		"Max possible deer population.",
 	)
 	foragingDeerGrowthCoefficient = flag.Float64(
 		"foragingDeerGrowthCoefficient",


### PR DESCRIPTION
As title.

Thanks @mpardalos for pointing out the `fConf` bug -- I thought that was a `_test.go` file by accident.

This was introduced in #146 

Fix also `MaxDeerPopulation`'s description that it is only used post-mvp--this is already activated now.

## Test plan

![image](https://user-images.githubusercontent.com/33488131/103181196-95c5e200-4896-11eb-9242-35229a83b014.png)
