### PR TITLE
[INFRA/CORE] Modify BaseClient to let clients inherit vars

### DIFF
--- a/internal/clients/team1/client.go
+++ b/internal/clients/team1/client.go
@@ -9,9 +9,9 @@ import (
 const id = shared.Team1
 
 func init() {
-	baseclient.RegisterClient(id, &client{Client: baseclient.NewClient(id)})
+	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
 }
 
 type client struct {
-	baseclient.Client
+	*baseclient.BaseClient
 }

--- a/internal/clients/team2/client.go
+++ b/internal/clients/team2/client.go
@@ -9,9 +9,9 @@ import (
 const id = shared.Team2
 
 func init() {
-	baseclient.RegisterClient(id, &client{Client: baseclient.NewClient(id)})
+	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
 }
 
 type client struct {
-	baseclient.Client
+	*baseclient.BaseClient
 }

--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -10,11 +10,11 @@ import (
 const id = shared.Team3
 
 func init() {
-	baseclient.RegisterClient(id, &client{Client: baseclient.NewClient(id)})
+	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
 }
 
 type client struct {
-	baseclient.Client
+	*baseclient.BaseClient
 }
 
 func (c *client) DemoEvaluation() {

--- a/internal/clients/team4/client.go
+++ b/internal/clients/team4/client.go
@@ -9,9 +9,9 @@ import (
 const id = shared.Team4
 
 func init() {
-	baseclient.RegisterClient(id, &client{Client: baseclient.NewClient(id)})
+	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
 }
 
 type client struct {
-	baseclient.Client
+	*baseclient.BaseClient
 }

--- a/internal/clients/team5/client.go
+++ b/internal/clients/team5/client.go
@@ -9,9 +9,9 @@ import (
 const id = shared.Team5
 
 func init() {
-	baseclient.RegisterClient(id, &client{Client: baseclient.NewClient(id)})
+	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
 }
 
 type client struct {
-	baseclient.Client
+	*baseclient.BaseClient
 }

--- a/internal/clients/team6/client.go
+++ b/internal/clients/team6/client.go
@@ -9,9 +9,9 @@ import (
 const id = shared.Team6
 
 func init() {
-	baseclient.RegisterClient(id, &client{Client: baseclient.NewClient(id)})
+	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
 }
 
 type client struct {
-	baseclient.Client
+	*baseclient.BaseClient
 }

--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -64,18 +64,23 @@ type ServerReadHandle interface {
 var ourPredictionInfo shared.PredictionInfo
 
 // NewClient produces a new client with the BaseClient already implemented.
-func NewClient(id shared.ClientID) Client {
-	return &BaseClient{id: id, communications: map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent{}}
+func NewClient(id shared.ClientID) *BaseClient {
+	return &BaseClient{
+		id:             id,
+		Communications: map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent{},
+	}
 }
 
 // BaseClient provides a basic implementation for all functions of the client interface and should always the interface fully.
 // All clients should be based off of this BaseClient to ensure that all clients implement the interface,
 // even when new features are added.
 type BaseClient struct {
-	id               shared.ClientID
-	clientGameState  gamestate.ClientGameState
-	communications   map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
-	serverReadHandle ServerReadHandle
+	id shared.ClientID
+
+	// exported variables are accessible by the client implementations
+	ClientGameState  gamestate.ClientGameState
+	Communications   map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
+	ServerReadHandle ServerReadHandle
 }
 
 // Echo prints a message to show that the client exists
@@ -95,7 +100,7 @@ func (c *BaseClient) GetID() shared.ClientID {
 // OPTIONAL: Overwrite, and make sure to keep the value of ServerReadHandle.
 // You will need it to access the game state through its GetGameStateMethod.
 func (c *BaseClient) Initialise(serverReadHandle ServerReadHandle) {
-	c.serverReadHandle = serverReadHandle
+	c.ServerReadHandle = serverReadHandle
 }
 
 // StartOfTurn handles the start of a new turn.
@@ -144,11 +149,10 @@ func (c *BaseClient) GetVoteForElection(roleToElect Role) []shared.ClientID {
 
 // ReceiveCommunication is a function called by IIGO to pass the communication sent to the client
 func (c *BaseClient) ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent) {
-	c.communications[sender] = append(c.communications[sender], data)
+	c.Communications[sender] = append(c.Communications[sender], data)
 }
 
 // GetCommunications is used for testing communications
 func (c *BaseClient) GetCommunications() *map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent {
-	return &c.communications
-
+	return &c.Communications
 }

--- a/internal/common/baseclient/baseclient_iigo.go
+++ b/internal/common/baseclient/baseclient_iigo.go
@@ -15,7 +15,7 @@ func (c *BaseClient) CommonPoolResourceRequest() shared.Resources {
 
 // ResourceReport is an island's self-report of its own resources.
 func (c *BaseClient) ResourceReport() shared.Resources {
-	return c.clientGameState.ClientInfo.Resources
+	return c.ClientGameState.ClientInfo.Resources
 }
 
 // RuleProposal is called by the President in IIGO to propose a

--- a/internal/common/baseclient/iito.go
+++ b/internal/common/baseclient/iito.go
@@ -6,7 +6,7 @@ import "github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 // This information is fed to OfferGifts of all other clients.
 // COMPULSORY, you need to implement this method
 func (c *BaseClient) RequestGift() uint {
-	if c.clientGameState.ClientInfo.LifeStatus == shared.Critical {
+	if c.ClientGameState.ClientInfo.LifeStatus == shared.Critical {
 		return 100
 	}
 	return 0


### PR DESCRIPTION
# Summary

Thank you to @MikeIsMike for pointing this out in #156. This extends #45 to let client implementations access `BaseClient` variables. This is neater, and allows real inheritance, previously not thought possible.

## Test Plan

- #156 has MWE tests, thanks @MikeIsMike 
- Unit tests pass
