### PR TITLE
Remove ClientGameState field in baseclient

### DIFF
--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -79,7 +79,6 @@ type BaseClient struct {
 	predictionInfo shared.PredictionInfo
 
 	// exported variables are accessible by the client implementations
-	ClientGameState  gamestate.ClientGameState
 	Communications   map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
 	ServerReadHandle ServerReadHandle
 }

--- a/internal/common/baseclient/baseclient_iigo.go
+++ b/internal/common/baseclient/baseclient_iigo.go
@@ -15,7 +15,7 @@ func (c *BaseClient) CommonPoolResourceRequest() shared.Resources {
 
 // ResourceReport is an island's self-report of its own resources.
 func (c *BaseClient) ResourceReport() shared.Resources {
-	return c.ClientGameState.ClientInfo.Resources
+	return c.ServerReadHandle.GetGameState().ClientInfo.Resources
 }
 
 // RuleProposal is called by the President in IIGO to propose a

--- a/internal/common/baseclient/iito.go
+++ b/internal/common/baseclient/iito.go
@@ -6,7 +6,7 @@ import "github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 // This information is fed to OfferGifts of all other clients.
 // COMPULSORY, you need to implement this method
 func (c *BaseClient) RequestGift() uint {
-	if c.ClientGameState.ClientInfo.LifeStatus == shared.Critical {
+	if c.ServerReadHandle.GetGameState().ClientInfo.LifeStatus == shared.Critical {
 		return 100
 	}
 	return 0


### PR DESCRIPTION
It has been deprecated in favour of ServerReadHandle, but the field was
still being used in a couple of places