### PR TITLE
Reformatted End Of Turn Events

### DIFF
--- a/internal/server/iigo.go
+++ b/internal/server/iigo.go
@@ -29,17 +29,9 @@ func (s *SOMASServer) updateIIGOTurnHistory(clientID shared.ClientID, pairs []ru
 	)
 }
 
-func (s *SOMASServer) runIIGOEndOfTurn() error {
-	s.logf("start runIIGOEndOfTurn")
-	defer s.logf("finish runIIGOEndOfTurn")
-
-	s.runIIGOAllocations()
-	s.runIIGOTax()
-
-	return nil
-}
-
-func (s *SOMASServer) runIIGOTax() {
+func (s *SOMASServer) runIIGOTax() error {
+	s.logf("start runIIGOTax")
+	defer s.logf("finish runIIGOTax")
 	clientMap := getNonDeadClients(s.gameState.ClientInfos, s.clientMap)
 	for clientID, v := range clientMap {
 		tax := v.GetTaxContribution()
@@ -62,9 +54,10 @@ func (s *SOMASServer) runIIGOTax() {
 		})
 
 	}
+	return nil
 }
 
-func (s *SOMASServer) runIIGOAllocations() {
+func (s *SOMASServer) runIIGOAllocations() error {
 	s.logf("start runIIGOAllocations")
 	defer s.logf("finish runIIGOAllocations")
 	clientMap := getNonDeadClients(s.gameState.ClientInfos, s.clientMap)
@@ -88,6 +81,7 @@ func (s *SOMASServer) runIIGOAllocations() {
 
 		}
 	}
+	return nil
 }
 
 func updateAliveIslands(aliveIslands []shared.ClientID) {

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -54,18 +54,31 @@ func (s *SOMASServer) runOrgs() error {
 }
 
 // endOfTurn performs end of turn updates
+// TODO: organise order of end of turn actions
 func (s *SOMASServer) endOfTurn() error {
 	s.logf("start endOfTurn")
 	defer s.logf("finish endOfTurn")
 
-	err := s.runOrgsEndOfTurn()
-	if err != nil {
-		return errors.Errorf("Failed to run orgs end of turn: %v", err)
+	if err := s.runIIGOTax(); err != nil {
+		return errors.Errorf("Failed to put taxes into common pool at end of turn: %v", err)
 	}
 
-	err = s.runForage()
-	if err != nil {
+	if err := s.runIIFOEndOfTurn(); err != nil {
+		return errors.Errorf("IIFO EndOfTurn error: %v", err)
+	}
+
+	// TODO: break IITO down into giving gifts and receiving gifts
+	if err := s.runIITOEndOfTurn(); err != nil {
+		return errors.Errorf("IITO EndOfTurn error: %v", err)
+	}
+
+	// TODO : break foraging down into foraging investments and foraging returns
+	if err := s.runForage(); err != nil {
 		return errors.Errorf("Failed to run hunt at end of turn: %v", err)
+	}
+
+	if err := s.runIIGOAllocations(); err != nil {
+		return errors.Errorf("Failed to get common pool allocations at end of turn: %v", err)
 	}
 
 	// probe for disaster
@@ -84,26 +97,6 @@ func (s *SOMASServer) endOfTurn() error {
 	err = s.updateIslandLivingStatus()
 	if err != nil {
 		return errors.Errorf("Failed to update island living status: %v", err)
-	}
-
-	return nil
-}
-
-// runOrgsEndOfTurn runs all the end of turn variants of the orgs.
-func (s *SOMASServer) runOrgsEndOfTurn() error {
-	s.logf("start runOrgsEndOfTurn")
-	defer s.logf("finish runOrgsEndOfTurn")
-
-	if err := s.runIIGOEndOfTurn(); err != nil {
-		return errors.Errorf("IIGO EndOfTurn error: %v", err)
-	}
-
-	if err := s.runIIFOEndOfTurn(); err != nil {
-		return errors.Errorf("IIFO EndOfTurn error: %v", err)
-	}
-
-	if err := s.runIITOEndOfTurn(); err != nil {
-		return errors.Errorf("IITO EndOfTurn error: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
# Summary

In response to PR #173. A more flexible end of turn execution that lets us adjust ordering if necessary. I believe all personal pool outgoings should happen before personal pool incomings and this setup will allow that.
