### PR TITLE
[VIS/WASM] (1) Add Go WASM API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
       run: cat output/output.json
     - name: Build website
       run: |
+        sudo bash build_wasm.sh
         cd website
         npm i -g yarn
         yarn install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       run: cat output/output.json
     - name: Test build website
       run: |
+        sudo bash build_wasm.sh
         cd website
         npm i -g yarn
         yarn install

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ SOMAS2020
 output
 
 .vscode
+
+*.wasm

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ After running, the `output` directory will contain the output of the program.
 ### Visualisation Website
 See [`website/README.md`](website/README.md)
 
+### WebAssembly Output
+
+A script is provided to compile the program into WebAssembly for use in the website.
+
+On Linux/maxOS,
+```bash
+./build_wasm.sh
+```
+
+On Windows,
+```bash
+build_cmd.cmd
+```
+
 ## Testing
 ```bash
 go test ./...

--- a/build_wasm.cmd
+++ b/build_wasm.cmd
@@ -1,0 +1,10 @@
+@echo off
+
+@REM cd to root
+cd %~dp0
+setlocal 
+    set GOOS=js
+    set GOARCH=wasm
+
+    go build -ldflags="-w -s" -o ./website/public/SOMAS2020.wasm
+endlocal

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+# ensure in root
+cd "$(dirname "$0")"
+
+GOOS=js GOARCH=wasm go build -ldflags="-w -s" -o ./website/public/SOMAS2020.wasm

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
+// +build !js
+
 // Package main is the main entrypoint of the program.
 package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,20 +13,11 @@ import (
 	"os"
 	"path"
 
-	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
-	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/server"
 	"github.com/SOMAS2020/SOMAS2020/pkg/fileutils"
 	"github.com/SOMAS2020/SOMAS2020/pkg/gitinfo"
 	"github.com/SOMAS2020/SOMAS2020/pkg/logger"
 )
-
-// output represents what is output into the output.json file
-type output struct {
-	GameStates []gamestate.GameState
-	Config     config.Config
-	GitInfo    gitinfo.GitInfo
-}
 
 const outputJSONFileName = "output.json"
 const outputLogFileName = "log.txt"
@@ -58,6 +52,7 @@ func initLogger() {
 }
 
 func main() {
+	flag.Parse()
 	gameConfig := parseConfig()
 	s := server.NewSOMASServer(gameConfig)
 	if gameStates, err := s.EntryPoint(); err != nil {

--- a/main_js.go
+++ b/main_js.go
@@ -1,0 +1,164 @@
+// +build js,wasm
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"reflect"
+	"strings"
+	"syscall/js"
+
+	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
+	"github.com/SOMAS2020/SOMAS2020/internal/server"
+	"github.com/SOMAS2020/SOMAS2020/pkg/logger"
+	"github.com/pkg/errors"
+)
+
+type flagInfo struct {
+	Name     string
+	Usage    string
+	DefValue string
+	Type     string
+}
+
+func main() {
+	js.Global().Set(
+		"RunGame", js.FuncOf(RunGame),
+	)
+	js.Global().Set(
+		"GetFlagsFormats", js.FuncOf(GetFlagsFormats),
+	)
+	select {}
+}
+
+// RunGame runs the game.
+// args[0] are optional arguments to set flag values
+// The format is `arg1=value,arg2=value,...`
+func RunGame(this js.Value, args []js.Value) interface{} {
+	gameConfig, err := getConfigFromArgs(args)
+	if err != nil {
+		return js.ValueOf(map[string]interface{}{
+			"error": convertError(err),
+		})
+	}
+
+	// log into a buffer
+	logBuf := bytes.Buffer{}
+	log.SetOutput(logger.NewLogWriter([]io.Writer{&logBuf}))
+
+	s := server.NewSOMASServer(gameConfig)
+
+	var o output
+	var outputJSON string
+	gameStates, err := s.EntryPoint()
+	if err != nil {
+		return js.ValueOf(map[string]interface{}{
+			"error": convertError(err),
+		})
+	}
+
+	o = output{
+		GameStates: gameStates,
+		Config:     gameConfig,
+		// no git info
+	}
+	outputJSON, err = getOutputJSON(o)
+
+	return js.ValueOf(map[string]interface{}{
+		"output": outputJSON,
+		"logs":   logBuf.String(),
+		"error":  convertError(err),
+	})
+}
+
+// GetFlagsFormats returns the format of the flags.
+// See flagInfo type for more information.
+func GetFlagsFormats(this js.Value, args []js.Value) interface{} {
+	flagInfos := []flagInfo{}
+	flagVisitor := flagVisitOuter(&flagInfos)
+	flag.VisitAll(flagVisitor)
+
+	output, err := getFlagsFormatsJSON(flagInfos)
+	if err != nil {
+		return js.ValueOf(map[string]interface{}{
+			"error": convertError(err),
+		})
+	}
+
+	return js.ValueOf(map[string]interface{}{
+		"output": output,
+		"error":  convertError(err),
+	})
+}
+
+func getConfigFromArgs(jsArgs []js.Value) (config.Config, error) {
+	args := strings.Split(jsArgs[0].String(), ",")
+
+	if len(args) == 1 && args[0] == "" {
+		// handle empty input
+		args = []string{}
+	}
+
+	flag.Parse()
+
+	for _, arg := range args {
+		nameValuePair := strings.Split(arg, "=")
+		if len(nameValuePair) != 2 {
+			return config.Config{}, errors.Errorf("Invalid arg: %v", arg)
+		}
+		name := nameValuePair[0]
+		val := nameValuePair[1]
+		err := flag.Set(name, val)
+		if err != nil {
+			return config.Config{}, errors.Errorf("Cannot set flag name '%v' with value '%v': %v", name, val, err)
+		}
+	}
+
+	return parseConfig(), nil
+}
+
+// getFlagBaseType processes the String of the reflect.Type of a flag to
+// only return the bare type.
+// e.g. *flag.float64Value -> float64
+func getFlagBaseType(f *flag.Flag) string {
+	s := reflect.TypeOf(f.Value).String()
+	return s[6 : len(s)-5]
+}
+
+func flagVisitOuter(fis *[]flagInfo) func(*flag.Flag) {
+	return func(f *flag.Flag) {
+		*fis = append(*fis, flagInfo{
+			Name:     f.Name,
+			Usage:    f.Usage,
+			DefValue: f.DefValue,
+			Type:     getFlagBaseType(f),
+		})
+		return
+	}
+}
+func getFlagsFormatsJSON(fis []flagInfo) (string, error) {
+	jsonBuf, err := json.Marshal(fis)
+	if err != nil {
+		return "", errors.Errorf("Failed to Marshal flags formats: %v", err)
+	}
+	return string(jsonBuf), nil
+}
+
+func getOutputJSON(o output) (string, error) {
+	jsonBuf, err := json.Marshal(o)
+	if err != nil {
+		return "", errors.Errorf("Failed to Marshal output: %v", err)
+	}
+	return string(jsonBuf), nil
+}
+
+func convertError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/params.go
+++ b/params.go
@@ -112,7 +112,6 @@ var (
 )
 
 func parseConfig() config.Config {
-	flag.Parse()
 	foragingConf := config.ForagingConfig{
 		MaxDeerPerHunt:        *foragingMaxDeerPerHunt,
 		IncrementalInputDecay: *foragingIncrementalInputDecay,

--- a/shared.go
+++ b/shared.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
+	"github.com/SOMAS2020/SOMAS2020/pkg/gitinfo"
+)
+
+// output represents what is output into the output.json file
+type output struct {
+	GameStates []gamestate.GameState
+	Config     config.Config
+	GitInfo    gitinfo.GitInfo
+}


### PR DESCRIPTION
# This PR is the start of a series of PRs that enable WASM. 

# DO NOT UPDATE FROM MAIN OR MERGE AFTER ACCEPTING! LET @lhl2617 DO IT

# Summary

- Add API to `RunGame` and `GetFlagsFormats`. 
- `RunGame` is to actually run a game, and the latter is for getting the formats of the flags
- Build wasm target in CI
- Update README.md

The arguments supplied to RunGame are of the format
```
"<arg>=<val>,<arg>=<val>,..."
```

## Additional Info
I followed a variety of guides, but most of them are not too great and only show part of the info required.
Ones used are:
- https://github.com/golang/go/wiki/WebAssembly
- https://dev.to/enbis/generate-and-run-webassembly-code-using-go-4fbp
- https://marianogappa.github.io/software/2020/04/01/webassembly-tinygo-cheesse/
- https://github.com/marianogappa/cheesse


## Test Plan

- In CI we trust.