### PR TITLE
[VIS/WASM] Fix bug in which args reset do not take effect

### DIFF
--- a/website/src/utils.ts
+++ b/website/src/utils.ts
@@ -1,3 +1,0 @@
-export function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
-  return value !== null && value !== undefined;
-}

--- a/website/src/wasmAPI.tsx
+++ b/website/src/wasmAPI.tsx
@@ -1,5 +1,4 @@
 import outputJSONData from './output/output.json'
-import { notEmpty } from './utils'
 
 // @ts-ignore
 const go: any = window.go
@@ -81,21 +80,14 @@ export const runGame = async (flags: Flag[]): Promise<RunGameReturnType> => {
 }
 
 /**
- * Take all the flags and get the ones that are different to their default values
- * then make them into the string argument required by runGame 
+ * Take all the flags and make them into the string argument required by runGame 
  * (`arg1=value,arg2=value,...`)
  * 
  * @param flags all input flags with information initially gotten from getFlagsFormats
  */
 const prepareFlags = async (flags: Flag[]): Promise<string> => {
     return flags
-        .map(f => {
-            if (f.Value !== f.DefValue) {
-                return `${f.Name}=${f.Value}`
-            }
-            return undefined
-        })
-        .filter(notEmpty)
+        .map(f => `${f.Name}=${f.Value}`)
         .join(`,`)
 }
 


### PR DESCRIPTION
# Summary

As title. This is because we only pass in non-default arguments; when the Go program has replaced the defaults with the new arguments it no longer resets the flag to its default.

It is possible to do the reset in the Go program, but it is more tedious.

This PR passes in _all_ flags and values, default or not.

## Test Plan

No longer possible to repro bug.