### PR TITLE
[VIS] Update scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,6 @@ jobs:
       run: cat output/output.json
     - name: Build website
       run: |
-        sudo bash build_wasm.sh
         cd website
         npm i -g yarn
         yarn install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
       run: cat output/output.json
     - name: Test build website
       run: |
-        sudo bash build_wasm.sh
         cd website
         npm i -g yarn
         yarn install

--- a/README.md
+++ b/README.md
@@ -28,9 +28,16 @@ After running, the `output` directory will contain the output of the program.
 ### Visualisation Website
 See [`website/README.md`](website/README.md)
 
-### WebAssembly Output
+### WebAssembly Build
 
-A script is provided to compile the program into WebAssembly for use in the website.
+Scripts provided to compile the program into WebAssembly for the website.
+
+#### If you have `node`
+```bash
+node ./website/scripts/buildWasm.js
+```
+
+#### Otherwise
 
 On Linux/maxOS,
 ```bash

--- a/website/README.md
+++ b/website/README.md
@@ -25,10 +25,6 @@ sudo npm i -g yarn
 
 `yarn install`
 
-### Make sure you have the output from the Go program
-
-To run the website, you must follow the steps in `running code` in the root [README.md](../README.md).\
-The `output` folder in the root of the repository must be present.
 
 ## Scripts
 

--- a/website/README.md
+++ b/website/README.md
@@ -27,21 +27,8 @@ sudo npm i -g yarn
 
 ### Make sure you have the output from the Go program
 
-To run the website, you must follow the steps in `running code` in the primary README.\
+To run the website, you must follow the steps in `running code` in the root [README.md](../README.md).\
 The `output` folder in the root of the repository must be present.
-
-### WebAssembly Output
-
-You also need to compile the Go program into WASM.\
-On Linux/maxOS,
-```bash
-./build_wasm.sh
-```
-
-On Windows,
-```bash
-build_cmd.cmd
-```
 
 ## Scripts
 

--- a/website/package.json
+++ b/website/package.json
@@ -15,10 +15,11 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "copyoutput": "node src/scripts/copyOutput.js",
-    "prestart": "yarn copyoutput",
+    "copyoutput": "node scripts/copyOutput.js",
+    "buildwasm": "node scripts/buildWasm.js",
+    "prestart": "yarn copyoutput && yarn buildwasm",
     "start": "react-scripts start",
-    "prebuild": "yarn copyoutput",
+    "prebuild": "yarn copyoutput && yarn buildwasm",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/website/scripts/buildWasm.js
+++ b/website/scripts/buildWasm.js
@@ -1,0 +1,37 @@
+/**
+ * buildWasm.js
+ * 
+ * This script builds the Go program in the repo base against wasm
+ * and stores the output in website/public/SOMAS2020.wasm
+ * 
+ * You can run this script using `yarn buildwasm`.
+ * This script also runs during prebuild and prestart.
+ */
+
+
+const path = require('path')
+const cp = require('child_process')
+
+try {
+    const websiteRoot = path.dirname(__dirname)
+    const repoRoot = path.dirname(websiteRoot)
+
+    const stdout = cp.execSync(
+        `go build -ldflags="-w -s" -o ./website/public/SOMAS2020.wasm`,
+        {
+            cwd: repoRoot,
+            env: {
+                ...process.env,
+                GOOS: `js`,
+                GOARCH: `wasm`,
+            }
+        }
+    )
+    console.log(stdout.toString())
+}
+catch (err) {
+    console.error(err)
+    process.exit(1)
+}
+
+console.log("Built SOMAS2020.wasm successfully")

--- a/website/scripts/copyOutput.js
+++ b/website/scripts/copyOutput.js
@@ -13,7 +13,7 @@ const fs = require('fs')
 const path = require('path')
 
 try {
-    const websiteRoot = path.dirname(path.dirname(__dirname))
+    const websiteRoot = path.dirname(__dirname)
     const repoRoot = path.dirname(websiteRoot)
 
     fse.copySync(

--- a/website/scripts/copyOutput.js
+++ b/website/scripts/copyOutput.js
@@ -4,6 +4,8 @@
  * This script copies the output from the completed Go program simulation
  * from the root of the repository.
  * 
+ * If the output is not found, this scripts attempts to run the simulation.
+ * 
  * You can run this script using `yarn copyoutput`.
  * This script also runs during prebuild and prestart.
  */
@@ -11,10 +13,22 @@
 const fse = require('fs-extra')
 const fs = require('fs')
 const path = require('path')
+const cp = require('child_process')
 
 try {
     const websiteRoot = path.dirname(__dirname)
     const repoRoot = path.dirname(websiteRoot)
+
+    if (!fs.existsSync(path.join(repoRoot, `output`))) {
+        console.log("Did not find simulation output, running simulation...")
+        const stdout = cp.execSync(
+            `go run .`,
+            {
+                cwd: repoRoot,
+            }
+        )
+        console.log(stdout.toString())
+    }
 
     fse.copySync(
         path.join(repoRoot, `output`), 

--- a/website/scripts/copyOutput.js
+++ b/website/scripts/copyOutput.js
@@ -4,6 +4,9 @@
  * This script copies the output from the completed Go program simulation
  * from the root of the repository.
  * 
+ * The logs are processed into a JSON list for ease of inclusion in the
+ * React App.
+ * 
  * If the output is not found, this scripts attempts to run the simulation.
  * 
  * You can run this script using `yarn copyoutput`.

--- a/website/src/scripts/copyOutput.js
+++ b/website/src/scripts/copyOutput.js
@@ -1,13 +1,32 @@
+/**
+ * copyOutput.js
+ * 
+ * This script copies the output from the completed Go program simulation
+ * from the root of the repository.
+ * 
+ * You can run this script using `yarn copyoutput`.
+ * This script also runs during prebuild and prestart.
+ */
+
 const fse = require('fs-extra')
 const fs = require('fs')
+const path = require('path')
 
 try {
-    fse.copySync(`../output`, `src/output`)
+    const websiteRoot = path.dirname(path.dirname(__dirname))
+    const repoRoot = path.dirname(websiteRoot)
+
+    fse.copySync(
+        path.join(repoRoot, `output`), 
+        path.join(websiteRoot, `src`, `output`),
+    )
     
-    const logTxt = fs.readFileSync(`src/output/log.txt`, `utf8`)
+    const logTxt = fs.readFileSync(
+        path.join(websiteRoot, `src`, `output`, `log.txt`), 
+        `utf8`)
     const logLines = logTxt.split(`\n`)
     
-    fs.writeFileSync(`src/output/log.txt.json`, JSON.stringify(logLines))
+    fs.writeFileSync(path.join(websiteRoot, `src`, `output`, `log.txt.json`), JSON.stringify(logLines))
 }
 catch (err) {
     console.error(err)


### PR DESCRIPTION
# Summary

- Move scripts to `website/scripts`
- Add `buildWasm.js` script to build wasm output -- @olly-larkin forgot this for example, and this shouldn't be a manual step.
- Update documentation
- Add `buildwasm` together with `copyoutput` to `prestart` and `prebuild` yarn commands.
- Remove unneeded WASM build step in CI

## Test Plan

`yarn start` OK