### PR TITLE
[VIS] Save output and flags locally

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "d3": "^6.3.1",
+    "localforage": "^1.9.0",
     "react": "^17.0.1",
     "react-bootstrap": "^1.4.0",
     "react-dom": "^17.0.1",

--- a/website/src/components/Artifacts/Artifacts.tsx
+++ b/website/src/components/Artifacts/Artifacts.tsx
@@ -46,9 +46,11 @@ const Artifacts = (props: Props) => {
   return <div style={{ textAlign: `left`, padding: `0 3vw` }} className={styles.root}>
     <Table striped bordered hover>
       <thead>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Download</th>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Download</th>
+        </tr>
       </thead>
       <tbody>
         {

--- a/website/src/components/NewRun/NewRun.tsx
+++ b/website/src/components/NewRun/NewRun.tsx
@@ -26,7 +26,7 @@ const FlagForm = (props: FlagFormProps) => {
             placement="top"
             overlay={
               <Tooltip id={flag.Name}>
-                {flag.Usage}
+                {flag.Usage} (Type: {flag.Type}, Default: {flag.DefValue})
               </Tooltip>
             }
           >

--- a/website/src/components/NewRun/NewRun.tsx
+++ b/website/src/components/NewRun/NewRun.tsx
@@ -73,6 +73,7 @@ const NewRun = () => {
     try {
       const newFlags = await setFlagHelper(flags, flagName, val)
       setFlags(newFlags)
+      setRunError(undefined)
     }
     catch (err) {
       setRunError(err.message)
@@ -96,6 +97,7 @@ const NewRun = () => {
       }
       const res = await runGameHelper(flags)
       setOutput(res)
+      setRunError(undefined)
     }
     catch (err) {
       setRunError(err.message)

--- a/website/src/components/NewRun/utils.ts
+++ b/website/src/components/NewRun/utils.ts
@@ -1,0 +1,71 @@
+import { LOCAL_FLAGS, LOCAL_OUTPUT } from "../../consts/localForage"
+import { Flag, getFlagsFormats, RunGameReturnType, runGame } from "../../wasmAPI"
+import * as localForage from "localforage"
+
+export const loadFlags = async (loadLocal: boolean = true): Promise<Map<string, Flag>> => {
+  const goFlags = await getFlagsFormats()
+  let fs: Map<string, Flag> = new Map()
+  goFlags.forEach(f => { fs.set(f.Name, { ...f, Value: f.DefValue }) })
+
+  if (loadLocal) {
+    // try to load local flags' values if present
+    const localFs: Map<string, Flag> | undefined | null = await localForage.getItem(LOCAL_FLAGS)
+    if (localFs) {
+      localFs.forEach(f => {
+        const origFlag = fs.get(f.Name)
+        if (origFlag) {
+          fs.set(f.Name, { ...origFlag, Value: f.Value })
+        }
+      })
+    }
+  }
+
+  return fs
+}
+
+export const loadLocalOutput = async () => {
+  const localOutput: RunGameReturnType | undefined | null = await localForage.getItem(LOCAL_OUTPUT)
+  return localOutput
+}
+
+export const runGameHelper = async (flags: Map<string, Flag>): Promise<RunGameReturnType> => {
+  const flagArr = Array.from(flags, ([_, value]) => value)
+  const output = await runGame(flagArr)
+
+  // async-ally save the flags and output in localForage
+  // best effort, so we don't really care if it's not oK
+  localForage.setItem(LOCAL_FLAGS, flags)
+    .then(() => console.debug(`Set local flags`))
+    .catch((err: any) => console.error(err))
+  localForage.setItem(LOCAL_OUTPUT, output)
+    .then(() => console.debug(`Set local output`))
+    .catch((err: any) => console.error(err))
+
+  return output
+}
+
+export const setFlagHelper = async (flags: Map<string, Flag> | undefined, flagName: string, val: string): Promise<Map<string, Flag>> => {
+  if (!flags) {
+    // should not happen
+    throw new Error(`Flags not loaded`)
+  }
+  const currFlag = flags.get(flagName)
+
+  if (!currFlag) {
+    throw new Error(`Unknown flag name ${flagName}`)
+  }
+  const newCurrFlag = { ...currFlag, Value: val }
+  return new Map(flags.set(flagName, newCurrFlag))
+}
+
+export const clearLocalOutput = async () => {
+  localForage.removeItem(LOCAL_OUTPUT)
+    .then(() => console.debug(`Clear local output`))
+    .catch((err: any) => console.error(err))
+}
+
+export const clearLocalFlags = async () => {
+  localForage.removeItem(LOCAL_FLAGS)
+    .then(() => console.debug(`Clear local flags`))
+    .catch((err: any) => console.error(err))
+}

--- a/website/src/components/NewRun/utils.ts
+++ b/website/src/components/NewRun/utils.ts
@@ -1,4 +1,4 @@
-import { LOCAL_FLAGS, LOCAL_OUTPUT } from "../../consts/localForage"
+import { NEW_RUN_FLAGS, NEW_RUN_OUTPUT } from "../../consts/localForage"
 import { Flag, getFlagsFormats, RunGameReturnType, runGame } from "../../wasmAPI"
 import * as localForage from "localforage"
 
@@ -9,7 +9,7 @@ export const loadFlags = async (loadLocal: boolean = true): Promise<Map<string, 
 
   if (loadLocal) {
     // try to load local flags' values if present
-    const localFs: Map<string, Flag> | undefined | null = await localForage.getItem(LOCAL_FLAGS)
+    const localFs: Map<string, Flag> | undefined | null = await localForage.getItem(NEW_RUN_FLAGS)
     if (localFs) {
       localFs.forEach(f => {
         const origFlag = fs.get(f.Name)
@@ -24,7 +24,7 @@ export const loadFlags = async (loadLocal: boolean = true): Promise<Map<string, 
 }
 
 export const loadLocalOutput = async () => {
-  const localOutput: RunGameReturnType | undefined | null = await localForage.getItem(LOCAL_OUTPUT)
+  const localOutput: RunGameReturnType | undefined | null = await localForage.getItem(NEW_RUN_OUTPUT)
   return localOutput
 }
 
@@ -34,10 +34,10 @@ export const runGameHelper = async (flags: Map<string, Flag>): Promise<RunGameRe
 
   // async-ally save the flags and output in localForage
   // best effort, so we don't really care if it's not oK
-  localForage.setItem(LOCAL_FLAGS, flags)
+  localForage.setItem(NEW_RUN_FLAGS, flags)
     .then(() => console.debug(`Set local flags`))
     .catch((err: any) => console.error(err))
-  localForage.setItem(LOCAL_OUTPUT, output)
+  localForage.setItem(NEW_RUN_OUTPUT, output)
     .then(() => console.debug(`Set local output`))
     .catch((err: any) => console.error(err))
 
@@ -59,13 +59,13 @@ export const setFlagHelper = async (flags: Map<string, Flag> | undefined, flagNa
 }
 
 export const clearLocalOutput = async () => {
-  localForage.removeItem(LOCAL_OUTPUT)
+  localForage.removeItem(NEW_RUN_OUTPUT)
     .then(() => console.debug(`Clear local output`))
     .catch((err: any) => console.error(err))
 }
 
 export const clearLocalFlags = async () => {
-  localForage.removeItem(LOCAL_FLAGS)
+  localForage.removeItem(NEW_RUN_FLAGS)
     .then(() => console.debug(`Clear local flags`))
     .catch((err: any) => console.error(err))
 }

--- a/website/src/consts/localForage.ts
+++ b/website/src/consts/localForage.ts
@@ -1,0 +1,4 @@
+// keys for localForage
+
+export const LOCAL_FLAGS = `LOCAL_FLAGS`
+export const LOCAL_OUTPUT = `LOCAL_OUTPUT`

--- a/website/src/consts/localForage.ts
+++ b/website/src/consts/localForage.ts
@@ -1,4 +1,4 @@
 // keys for localForage
 
-export const LOCAL_FLAGS = `LOCAL_FLAGS`
-export const LOCAL_OUTPUT = `LOCAL_OUTPUT`
+export const NEW_RUN_FLAGS = `NEW_RUN_FLAGS`
+export const NEW_RUN_OUTPUT = `NEW_RUN_OUTPUT`

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6266,6 +6266,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 immer@7.0.9:
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
@@ -7453,6 +7458,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -7499,6 +7511,13 @@ loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+localforage@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.9.0.tgz#f3e4d32a8300b362b4634cc4e066d9d00d2f09d1"
+  integrity sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Summary

## Storage
- Save flags and output into IndexedDB (localForage) upon a successful run.
- Load these saved items if present on New Run page load
- Clear storage as appropriate during resets.
## New Run
- Clear errors when runs successful
## Flags
- Display type and def properly

## Additional Information

- Fix `<thead><tr>` bug

## Test Plan

- Behaviour described tested successfully.
- Type and def for flag:
  ![image](https://user-images.githubusercontent.com/33488131/103446246-553edd80-4c75-11eb-9ac4-a18f09627bde.png)

