### PR TITLE
[INFRA/CORE] Handle invalid iota flags

### DIFF
--- a/internal/common/shared/disasters.go
+++ b/internal/common/shared/disasters.go
@@ -2,9 +2,9 @@ package shared
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
+	"github.com/pkg/errors"
 )
 
 // Coordinate is a floating point number that can be used represent a position on the map
@@ -50,12 +50,11 @@ func (s SpatialPDFType) MarshalJSON() ([]byte, error) {
 }
 
 // ParseSpatialPDFType gets the SpatialPDFType based on the number
-func ParseSpatialPDFType(x int) SpatialPDFType {
+func ParseSpatialPDFType(x int) (SpatialPDFType, error) {
 	if x >= 0 && SpatialPDFType(x) < spatialPDFTypeEnd {
-		return SpatialPDFType(x)
+		return SpatialPDFType(x), nil
 	}
-	log.Printf("Unknown SpatialPDFType specified: '%v'\nUse --help. Defaulting to %v", x, Uniform)
-	return Uniform
+	return Uniform, errors.Errorf("Unknown SpatialPDFType specified: '%v'.", x)
 }
 
 // HelpSpatialPDFType returns a help string for SpatialPDFType

--- a/internal/common/shared/resources.go
+++ b/internal/common/shared/resources.go
@@ -2,9 +2,9 @@ package shared
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/SOMAS2020/SOMAS2020/pkg/miscutils"
+	"github.com/pkg/errors"
 )
 
 // ResourceDistributionStrategy characterises the different ways in which resources can be distributed
@@ -47,12 +47,11 @@ func (rd ResourceDistributionStrategy) MarshalJSON() ([]byte, error) {
 }
 
 // ParseResourceDistributionStrategy gets the ResourceDistributionStrategy based on an iota index
-func ParseResourceDistributionStrategy(x int) ResourceDistributionStrategy {
+func ParseResourceDistributionStrategy(x int) (ResourceDistributionStrategy, error) {
 	if x >= 0 && ResourceDistributionStrategy(x) < _resourceDistrEnd {
-		return ResourceDistributionStrategy(x)
+		return ResourceDistributionStrategy(x), nil
 	}
-	log.Printf("Unknown ResourceDistribution Strategy specified: '%v'\nUse --help. Defaulting to %v", x, EqualSplit)
-	return EqualSplit
+	return EqualSplit, errors.Errorf("Unknown ResourceDistribution Strategy specified: '%v'.", x)
 }
 
 // HelpResourceDistributionStrategy returns a help string for ResourceDistributionStrategy

--- a/main.go
+++ b/main.go
@@ -56,7 +56,11 @@ func initLogger() {
 func main() {
 	timeStart := time.Now()
 	flag.Parse()
-	gameConfig := parseConfig()
+	gameConfig, err := parseConfig()
+	if err != nil {
+		log.Printf("Flag parse error: %v\nUse --help.", err)
+		os.Exit(1)
+	}
 	s := server.NewSOMASServer(gameConfig)
 	if gameStates, err := s.EntryPoint(); err != nil {
 		log.Printf("Run failed with: %+v", err)

--- a/main_js.go
+++ b/main_js.go
@@ -41,6 +41,10 @@ func main() {
 // args[0] are optional arguments to set flag values
 // The format is `arg1=value,arg2=value,...`
 func RunGame(this js.Value, args []js.Value) interface{} {
+	// log into a buffer
+	logBuf := bytes.Buffer{}
+	log.SetOutput(logger.NewLogWriter([]io.Writer{&logBuf}))
+
 	timeStart := time.Now()
 	gameConfig, err := getConfigFromArgs(args)
 	if err != nil {
@@ -48,10 +52,6 @@ func RunGame(this js.Value, args []js.Value) interface{} {
 			"error": convertError(err),
 		})
 	}
-
-	// log into a buffer
-	logBuf := bytes.Buffer{}
-	log.SetOutput(logger.NewLogWriter([]io.Writer{&logBuf}))
 
 	s := server.NewSOMASServer(gameConfig)
 
@@ -129,7 +129,12 @@ func getConfigFromArgs(jsArgs []js.Value) (config.Config, error) {
 		}
 	}
 
-	return parseConfig(), nil
+	conf, err := parseConfig()
+	if err != nil {
+		return conf, errors.Errorf("Flag parse error: %v", err)
+	}
+
+	return conf, nil
 }
 
 // getFlagBaseType processes the String of the reflect.Type of a flag to

--- a/params.go
+++ b/params.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -155,8 +156,23 @@ var (
 	)
 )
 
-func parseConfig() config.Config {
+func parseConfig() (config.Config, error) {
 	flag.Parse()
+
+	parsedForagingDeerDistributionStrategy, err := shared.ParseResourceDistributionStrategy(*foragingDeerDistributionStrategy)
+	if err != nil {
+		return config.Config{}, errors.Errorf("Error parsing foragingDeerDistributionStrategy: %v", err)
+	}
+
+	parsedForagingFishingDistributionStrategy, err := shared.ParseResourceDistributionStrategy(*foragingFishingDistributionStrategy)
+	if err != nil {
+		return config.Config{}, errors.Errorf("Error parsing foragingFishingDistributionStrategy: %v", err)
+	}
+
+	parsedDisasterSpatialPDFType, err := shared.ParseSpatialPDFType(*disasterSpatialPDFType)
+	if err != nil {
+		return config.Config{}, errors.Errorf("Error parsing disasterSpatialPDFType: %v", err)
+	}
 
 	deerConf := config.DeerHuntConfig{
 		//Deer parameters
@@ -165,7 +181,7 @@ func parseConfig() config.Config {
 		BernoulliProb:         *foragingDeerBernoulliProb,
 		ExponentialRate:       *foragingDeerExponentialRate,
 		ResourceMultiplier:    *foragingDeerResourceMultiplier,
-		DistributionStrategy:  shared.ParseResourceDistributionStrategy(*foragingDeerDistributionStrategy),
+		DistributionStrategy:  parsedForagingDeerDistributionStrategy,
 
 		MaxDeerPopulation:     *foragingDeerMaxPopulation,
 		DeerGrowthCoefficient: *foragingDeerGrowthCoefficient,
@@ -177,7 +193,7 @@ func parseConfig() config.Config {
 		Mean:                  *foragingFishingMean,
 		Variance:              *foragingFishingVariance,
 		ResourceMultiplier:    *foragingFishingResourceMultiplier,
-		DistributionStrategy:  shared.ParseResourceDistributionStrategy(*foragingFishingDistributionStrategy),
+		DistributionStrategy:  parsedForagingFishingDistributionStrategy,
 	}
 	foragingConf := config.ForagingConfig{
 		DeerHuntConfig: deerConf,
@@ -189,7 +205,7 @@ func parseConfig() config.Config {
 		YMin:            *disasterYMin,
 		YMax:            *disasterYMax,
 		GlobalProb:      *disasterGlobalProb,
-		SpatialPDFType:  shared.ParseSpatialPDFType(*disasterSpatialPDFType),
+		SpatialPDFType:  parsedDisasterSpatialPDFType,
 		MagnitudeLambda: *disasterMagnitudeLambda,
 	}
 	return config.Config{
@@ -202,5 +218,5 @@ func parseConfig() config.Config {
 		MaxCriticalConsecutiveTurns: *maxCriticalConsecutiveTurns,
 		ForagingConfig:              foragingConf,
 		DisasterConfig:              disasterConf,
-	}
+	}, nil
 }


### PR DESCRIPTION
# Summary

- Return error instead of defaulting to a value in iota parsing
- In WASM code, set logger earlier so we catch potential logs in parsing config

## Test Plan
- CLI
```
$ go run . --disasterSpatialPDFType 69
2021/01/01 22:57:55 Flag parse error: Error parsing disasterSpatialPDFType: Unknown SpatialPDFType specified: '69'.
Use --help.
exit status 1
```

- Website
![image](https://user-images.githubusercontent.com/33488131/103447539-7824be00-4c84-11eb-8d87-643d7b8bec37.png)
![image](https://user-images.githubusercontent.com/33488131/103447587-1dd82d00-4c85-11eb-8b8b-5d98d3ca150b.png)
