### PR TITLE
[INFRA/CORE] Read Only Access to IIGO Role IDs

### DIFF
--- a/internal/common/gamestate/clientgamestate.go
+++ b/internal/common/gamestate/clientgamestate.go
@@ -18,4 +18,9 @@ type ClientGameState struct {
 
 	// CommonPool
 	CommonPool shared.Resources
+
+	// Islands holding IIGO roles
+	SpeakerID   shared.ClientID
+	JudgeID     shared.ClientID
+	PresidentID shared.ClientID
 }

--- a/internal/common/gamestate/gamestate.go
+++ b/internal/common/gamestate/gamestate.go
@@ -31,6 +31,7 @@ type GameState struct {
 
 	// IITO Transactions
 	IITOTransactions map[shared.ClientID]shared.GiftResponseDict
+
 	// Orchestration
 	SpeakerID   shared.ClientID
 	JudgeID     shared.ClientID

--- a/internal/common/gamestate/gamestate.go
+++ b/internal/common/gamestate/gamestate.go
@@ -64,6 +64,9 @@ func (g *GameState) GetClientGameStateCopy(id shared.ClientID) ClientGameState {
 		ClientInfo:         g.ClientInfos[id].Copy(),
 		ClientLifeStatuses: clientLifeStatuses,
 		CommonPool:         g.CommonPool,
+		SpeakerID:          g.SpeakerID,
+		JudgeID:            g.JudgeID,
+		PresidentID:        g.PresidentID,
 	}
 }
 


### PR DESCRIPTION
# Summary

The President, Speaker and Judge role IDs are now available in ClientGameState through the ServerReadHandle so that islands are able to verify that IIGO communication is coming from the expected islands in power.

## Additional Information

As discussed in issue #164 

## Test Plan

All tests still pass.