### PR TITLE
[VIS] Rebuild visualisations interface

### DIFF
--- a/website/src/App.css
+++ b/website/src/App.css
@@ -1,3 +1,10 @@
 .lightbluelink {
   color: lightblue;
 }
+
+.custom-alert {
+  max-width: 90vw;
+  margin: auto;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}

--- a/website/src/components/CIOutput/CIOutput.tsx
+++ b/website/src/components/CIOutput/CIOutput.tsx
@@ -7,7 +7,7 @@ import Artifacts from '../Artifacts/Artifacts'
 const processedOutputLog = outputLog.join(`\n`)
 
 const CIOutput = () => {
-  return <div>
+  return <div style={{ paddingTop: 24 }}>
     <h1>CI Output</h1>
     <h3 style={{ marginTop: 24 }}>Artifacts</h3>
     <Artifacts output={outputJSON} logs={processedOutputLog} />

--- a/website/src/components/NewRun/NewRun.tsx
+++ b/website/src/components/NewRun/NewRun.tsx
@@ -121,7 +121,7 @@ const NewRun = () => {
     setFlags(fs)
   }
 
-  return <div>
+  return <div style={{ paddingTop: 24 }}>
     <h1>New Run</h1>
 
     {
@@ -141,7 +141,7 @@ const NewRun = () => {
     }
     {
       runError &&
-      <Alert variant="danger" onClose={() => setRunError(undefined)} dismissible style={{ maxWidth: `90vw`, margin: `auto`, marginTop: 24 }}>
+      <Alert variant="danger" onClose={() => setRunError(undefined)} dismissible className="custom-alert">
         <Alert.Heading>Oh reeeeeeeeee!</Alert.Heading>
         <p>{runError}</p>
       </Alert>

--- a/website/src/components/Visualisations/Game/Game.tsx
+++ b/website/src/components/Visualisations/Game/Game.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import logo from '../../../assets/logo/logo512.png';
 import styles from './Game.module.css';
+import { OutputJSONType } from "../../../consts/types";
 // import SampleVis from '../visualisation/SampleVis';
 
-const Game = () => {
+const Game = (props: { output: OutputJSONType }) => {
   return (
     <div>
       <img src={logo} className={styles.appLogo} alt="logo" />

--- a/website/src/components/Visualisations/IIFO/IIFO.tsx
+++ b/website/src/components/Visualisations/IIFO/IIFO.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import logo from "../../../assets/logo/logo512.png";
 import styles from "./IIFO.module.css";
+import { OutputJSONType } from "../../../consts/types";
 
-const IIFO = () => {
+const IIFO = (props: { output: OutputJSONType }) => {
   return (
     <div className={styles.root}>
       <img src={logo} className={styles.appLogo} alt="logo" />

--- a/website/src/components/Visualisations/IIGO/IIGO.tsx
+++ b/website/src/components/Visualisations/IIGO/IIGO.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import logo from '../../../assets/logo/logo512.png';
 import styles from './IIGO.module.css';
+import { OutputJSONType } from "../../../consts/types";
 
-const IIGO = () => {
+const IIGO = (props: { output: OutputJSONType }) => {
   return (
     <div className={styles.root}>
       <img src={logo} className={styles.appLogo} alt="logo" />

--- a/website/src/components/Visualisations/IITO/IITO.tsx
+++ b/website/src/components/Visualisations/IITO/IITO.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import logo from "../../../assets/logo/logo512.png";
 import styles from "./IITO.module.css";
+import { OutputJSONType } from "../../../consts/types";
 
-const IITO = () => {
+const IITO = (props: { output: OutputJSONType }) => {
   return (
     <div className={styles.root}>
       <img src={logo} className={styles.appLogo} alt="logo" />

--- a/website/src/components/Visualisations/Resources/Resources.tsx
+++ b/website/src/components/Visualisations/Resources/Resources.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import logo from "../../../assets/logo/logo512.png";
 import styles from "./Resources.module.css";
+import { OutputJSONType } from "../../../consts/types";
 
-const Resources = () => {
+const Resources = (props: { output: OutputJSONType }) => {
   return (
     <div className={styles.root}>
       <img src={logo} className={styles.appLogo} alt="logo" />

--- a/website/src/components/Visualisations/Roles/Roles.tsx
+++ b/website/src/components/Visualisations/Roles/Roles.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import logo from "../../../assets/logo/logo512.png";
 import styles from "./Roles.module.css";
+import { OutputJSONType } from "../../../consts/types";
 
-const Roles = () => {
+const Roles = (props: { output: OutputJSONType }) => {
   return (
     <div className={styles.root}>
       <img src={logo} className={styles.appLogo} alt="logo" />

--- a/website/src/components/Visualisations/Visualisations.tsx
+++ b/website/src/components/Visualisations/Visualisations.tsx
@@ -1,6 +1,152 @@
-export { default as Game } from "./Game/Game";
-export { default as Resources } from "./Resources/Resources";
-export { default as Roles } from "./Roles/Roles";
-export { default as IIGO } from "./IIGO/IIGO";
-export { default as IITO } from "./IITO/IITO";
-export { default as IIFO } from "./IIFO/IIFO";
+import React, { useEffect, useState } from "react"
+import VisualisationsNavbar from "./VisualisationsNavbar"
+import { Button, Alert } from "react-bootstrap"
+import { useHistory, Route, Switch } from "react-router-dom";
+import { gamevisualisation, visualisations, iifovisualisation, iigovisualisation, iitovisualisation, resourcesvisualisation, rolesvisualisation } from "../../consts/paths";
+import { OutputJSONType } from "../../consts/types";
+import { GitHash } from "../../consts/info";
+import { initialLoadingState, useLoadingState } from "../../contexts/loadingState";
+import { loadLocalVisOutput, clearLocalVisOutput, storeLocalVisOutput } from "./utils";
+import Game from './Game/Game'
+import IIFO from './IIFO/IIFO'
+import IITO from './IITO/IITO'
+import IIGO from './IIGO/IIGO'
+import Resources from './Resources/Resources'
+import Roles from './Roles/Roles'
+
+const Visualisations = () => {
+  const [output, setOutput] = useState<OutputJSONType | undefined>(undefined)
+  const [, setLoading] = useLoadingState()
+  const history = useHistory()
+  const [error, setError] = useState<string | undefined>(undefined)
+  const [warning, setWarning] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    onDidMount()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const onDidMount = async () => {
+    setLoading({ loading: true, loadingText: `We're hard at work!` })
+    try {
+      const o = await loadLocalVisOutput()
+      if (o) {
+        setOutput(o)
+        history.push(gamevisualisation)
+      }
+    }
+    catch (err) {
+      // if error, just assume not stored at all
+      console.error(err)
+    }
+    setLoading(initialLoadingState)
+  }
+
+  useEffect(() => {
+    if (output) {
+      try {
+        const gotGitHash = output.GitInfo.Hash
+        if (gotGitHash !== GitHash) {
+          setWarning(`This website was built on commit "${GitHash}", and the output you're trying to visualise ` +
+            ` was produced on commit "${output.GitInfo.Hash}". There may be incompatibilities!`)
+        }
+        else {
+          setWarning(undefined)
+        }
+      }
+      catch (err) {
+        // can't read output.GitInfo.Hash, just reset which clears localforage as well
+        handleReset()
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [output])
+
+  const handleReset = async () => {
+    setLoading({ loading: true, loadingText: `Cleaning up your mess!` })
+    setOutput(undefined)
+    await clearLocalVisOutput()
+    history.push(visualisations)
+    setLoading(initialLoadingState)
+    setError(undefined)
+    setWarning(undefined)
+  }
+
+  const onUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    setLoading({ loading: true, loadingText: `Reading your file!` })
+
+    try {
+      // @ts-ignore silence, typechecker
+      const file: Blob | null = event.target.files[0]
+      if (!file || !(file instanceof Blob)) {
+        throw new Error('No or unsupported file uploaded')
+      }
+      const outputText = await file.text()
+      const o = JSON.parse(outputText) as OutputJSONType
+      try {
+        // find githash to check whether the JSON is ok
+        const gotGitHash = o.GitInfo.Hash
+        console.debug(gotGitHash)
+      } catch (err) {
+        throw new Error(`Unsupported file.`)
+      }
+      setOutput(o)
+      await storeLocalVisOutput(o)
+      setError(undefined)
+    }
+    catch (err) {
+      setError(err.message)
+    }
+    history.push(gamevisualisation)
+    setLoading(initialLoadingState)
+  }
+
+  return <>
+    {
+      output && <>
+        <VisualisationsNavbar reset={handleReset} />
+      </>
+    }
+    <div style={{ paddingTop: 24 }}>
+      {
+        error &&
+        <Alert variant="danger" onClose={() => setError(undefined)} dismissible className="custom-alert">
+          <Alert.Heading>Oh reeeeeeeeee!</Alert.Heading>
+          <p>{error}</p>
+        </Alert>
+      }
+      {
+        warning &&
+        <Alert variant="warning" onClose={() => setWarning(undefined)} dismissible className="custom-alert">
+          <Alert.Heading>Rough seas ahead!</Alert.Heading>
+          <p>{warning}</p>
+        </Alert>
+      }
+      {
+        output ?
+          <Switch>
+            <Route path={gamevisualisation} exact component={() => <Game output={output} />} />
+            <Route path={iigovisualisation} exact component={() => <IIGO output={output} />} />
+            <Route path={iitovisualisation} exact component={() => <IITO output={output} />} />
+            <Route path={iifovisualisation} exact component={() => <IIFO output={output} />} />
+            <Route path={rolesvisualisation} exact component={() => <Roles output={output} />} />
+            <Route path={resourcesvisualisation} exact component={() => <Resources output={output} />} />
+          </Switch>
+          :
+          <>
+            <h1>Visualisations</h1>
+            <h5 style={{ marginTop: 24 }}>Upload output JSON file</h5>
+
+            <Button variant='warning'>
+              <label htmlFor='multi' style={{ margin: 0 }}>
+                Upload
+            </label>
+              <input style={{ display: 'none' }} type='file' accept='.json' id='multi' onChange={onUpload} />
+            </Button>
+          </>
+      }
+    </div>
+  </>
+}
+
+export default Visualisations

--- a/website/src/components/Visualisations/VisualisationsNavbar.tsx
+++ b/website/src/components/Visualisations/VisualisationsNavbar.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react"
+import { Navbar, Nav } from "react-bootstrap";
+import { LinkContainer } from "react-router-bootstrap";
+import { gamevisualisation, iigovisualisation, iitovisualisation, iifovisualisation, rolesvisualisation, resourcesvisualisation, visualisations } from "../../consts/paths";
+
+const VisualisationsNavbar = (props: { reset: () => any }) => {
+  const [navExpanded, setNavExpanded] = useState(false);
+  const closeNav = () => setNavExpanded(false);
+  const getNavLink = (text: string, link: string) => (
+    <LinkContainer to={link} onClick={closeNav}>
+      <Nav.Link>{text}</Nav.Link>
+    </LinkContainer>
+  )
+  const handleReset = () => {
+    const { reset } = props
+    reset()
+    closeNav()
+  }
+
+  return (
+    <>
+      <Navbar
+        bg="primary"
+        variant="dark"
+        expand="lg"
+        onToggle={() => setNavExpanded(!navExpanded)}
+        expanded={navExpanded}
+      >
+        <Navbar.Toggle aria-controls="basic-navbar-nav" onClick={closeNav} />
+        <Navbar.Collapse id="basic-navbar-nav" className="justify-content-end">
+          <Nav className="mr-auto">
+            {getNavLink("Game", gamevisualisation)}
+            {getNavLink("IIGO", iigovisualisation)}
+            {getNavLink("IITO", iitovisualisation)}
+            {getNavLink("IIFO", iifovisualisation)}
+            {getNavLink("Roles", rolesvisualisation)}
+            {getNavLink("Resources", resourcesvisualisation)}
+          </Nav>
+          <Nav>
+            <LinkContainer exact={true} to={visualisations} onClick={handleReset}>
+              <Nav.Link>Reset</Nav.Link>
+            </LinkContainer>
+          </Nav>
+
+        </Navbar.Collapse>
+      </Navbar>
+    </>
+  )
+}
+
+export default VisualisationsNavbar

--- a/website/src/components/Visualisations/utils.ts
+++ b/website/src/components/Visualisations/utils.ts
@@ -1,0 +1,17 @@
+import * as localForage from 'localforage'
+import { VIS_OUTPUT } from '../../consts/localForage'
+import { OutputJSONType } from '../../consts/types'
+
+export const loadLocalVisOutput = async () => {
+    const got: OutputJSONType | null | undefined = await localForage.getItem(VIS_OUTPUT)
+    if (got) return got
+    return undefined
+}
+
+export const storeLocalVisOutput = async (o: OutputJSONType) => {
+    await localForage.setItem(VIS_OUTPUT, o)
+}
+
+export const clearLocalVisOutput = async () => {
+    await localForage.removeItem(VIS_OUTPUT)
+}

--- a/website/src/consts/info.ts
+++ b/website/src/consts/info.ts
@@ -1,3 +1,4 @@
 import outputJSONData from '../output/output.json'
 
 export const teamIDs = outputJSONData.AuxInfo.TeamIDs
+export const GitHash = outputJSONData.GitInfo.Hash

--- a/website/src/consts/localForage.ts
+++ b/website/src/consts/localForage.ts
@@ -2,3 +2,4 @@
 
 export const NEW_RUN_FLAGS = `NEW_RUN_FLAGS`
 export const NEW_RUN_OUTPUT = `NEW_RUN_OUTPUT`
+export const VIS_OUTPUT = `VIS_OUTPUT`

--- a/website/src/consts/paths.ts
+++ b/website/src/consts/paths.ts
@@ -1,5 +1,6 @@
 export const cioutput = `/cioutput`
 export const newrun = `/newrun`
+export const visualisations = `/visualisation`
 export const gamevisualisation = `/visualisation/game`
 export const iigovisualisation = `/visualisation/iigo`
 export const iitovisualisation = `/visualisation/iito`

--- a/website/src/consts/types.ts
+++ b/website/src/consts/types.ts
@@ -1,0 +1,3 @@
+import outputJSONData from '../output/output.json'
+
+export type OutputJSONType = typeof outputJSONData

--- a/website/src/containers/AppLayout/AppLayout.module.css
+++ b/website/src/containers/AppLayout/AppLayout.module.css
@@ -3,7 +3,7 @@
 }
 
 .content {
-    padding: 100px 0;
+    padding: 56px 0;
     min-height: 95vh;
     text-align: center;
 }

--- a/website/src/containers/AppLayout/Content/Content.tsx
+++ b/website/src/containers/AppLayout/Content/Content.tsx
@@ -3,18 +3,13 @@ import { Route, Switch } from "react-router-dom";
 import {
   cioutput,
   newrun,
-  gamevisualisation,
-  iigovisualisation,
-  iitovisualisation,
-  iifovisualisation,
-  rolesvisualisation,
-  resourcesvisualisation,
+  visualisations,
 } from "../../../consts/paths";
 
 import Home from "../../../components/Home/Home";
 import CIOutput from "../../../components/CIOutput/CIOutput";
 import NewRun from "../../../components/NewRun/NewRun";
-import * as Visualisations from "../../../components/Visualisations/Visualisations";
+import Visualisations from "../../../components/Visualisations/Visualisations";
 
 const Content = () => {
   return (
@@ -22,20 +17,7 @@ const Content = () => {
       <Switch>
         <Route path={cioutput} exact component={CIOutput} />
         <Route path={newrun} exact component={NewRun} />
-        <Route path={gamevisualisation} exact component={Visualisations.Game} />
-        <Route path={iigovisualisation} exact component={Visualisations.IIGO} />
-        <Route path={iitovisualisation} exact component={Visualisations.IITO} />
-        <Route path={iifovisualisation} exact component={Visualisations.IIFO} />
-        <Route
-          path={rolesvisualisation}
-          exact
-          component={Visualisations.Roles}
-        />
-        <Route
-          path={resourcesvisualisation}
-          exact
-          component={Visualisations.Resources}
-        />
+        <Route path={visualisations} component={Visualisations} />
         <Route component={Home} />
       </Switch>
     </div>

--- a/website/src/containers/AppLayout/Navbar/Navbar.tsx
+++ b/website/src/containers/AppLayout/Navbar/Navbar.tsx
@@ -1,16 +1,11 @@
 import React, { useState } from "react";
-import { Navbar, Nav, NavDropdown } from "react-bootstrap";
+import { Navbar, Nav } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
 import {
   cioutput,
   newrun,
-  gamevisualisation,
-  iigovisualisation,
-  iitovisualisation,
-  iifovisualisation,
-  resourcesvisualisation,
-  rolesvisualisation,
+  visualisations,
 } from "../../../consts/paths";
 import outputJSONData from "../../../output/output.json";
 
@@ -25,13 +20,7 @@ const AppNavbar = () => {
     <LinkContainer to={link} onClick={closeNav}>
       <Nav.Link className="lightbluelink">{text}</Nav.Link>
     </LinkContainer>
-  );
-
-  const getNavDropdownLink = (text: string, link: string) => (
-    <LinkContainer to={link} onClick={closeNav}>
-      <NavDropdown.Item className="lightbluelink">{text}</NavDropdown.Item>
-    </LinkContainer>
-  );
+  )
 
   return (
     <>
@@ -71,14 +60,7 @@ const AppNavbar = () => {
           <Nav>
             {getNavLink("New Run", newrun)}
             {getNavLink("CI Output", cioutput)}
-            <NavDropdown title="Visualisations" id="collabsible-nav-dropdown">
-              {getNavDropdownLink("Game", gamevisualisation)}
-              {getNavDropdownLink("IIGO", iigovisualisation)}
-              {getNavDropdownLink("IITO", iitovisualisation)}
-              {getNavDropdownLink("IIFO", iifovisualisation)}
-              {getNavDropdownLink("Resources", resourcesvisualisation)}
-              {getNavDropdownLink("Roles", rolesvisualisation)}
-            </NavDropdown>
+            {getNavLink("Visualisations", visualisations)}
           </Nav>
         </Navbar.Collapse>
       </Navbar>

--- a/website/src/wasmAPI.tsx
+++ b/website/src/wasmAPI.tsx
@@ -1,3 +1,4 @@
+import { OutputJSONType } from './consts/types'
 import outputJSONData from './output/output.json'
 import './wasmjs/wasm_exec'
 
@@ -20,7 +21,7 @@ type RunGameReturnTypeWASM = {
 }
 
 export type RunGameReturnType = {
-    output: typeof outputJSONData,
+    output: OutputJSONType,
     logs: string,
 }
 
@@ -77,7 +78,7 @@ export const runGame = async (flags: Flag[]): Promise<RunGameReturnType> => {
         throw new Error(`Can't get output or logs`)
     }
 
-    const processedOutput = JSON.parse(result.output) as typeof outputJSONData
+    const processedOutput = JSON.parse(result.output) as OutputJSONType
 
     // we need to patch git info
     processedOutput.GitInfo = outputJSONData.GitInfo


### PR DESCRIPTION
# Summary

- Remove dropdown for vis
- Add vis upload json page
  - ![image](https://user-images.githubusercontent.com/33488131/103461572-3b55d700-4d17-11eb-88f9-624328488229.png)
- Add vis inner navbar
  - ![image](https://user-images.githubusercontent.com/33488131/103461577-4c064d00-4d17-11eb-987c-666eae00cec6.png)
- Errors in vis when unsupported file:
  - ![image](https://user-images.githubusercontent.com/33488131/103461579-5c1e2c80-4d17-11eb-8358-fa1058f4d390.png)
  - ![image](https://user-images.githubusercontent.com/33488131/103461585-69d3b200-4d17-11eb-90a2-be26c8e0bf22.png)
- Warning when git hash mismatch
  - ![image](https://user-images.githubusercontent.com/33488131/103461593-78ba6480-4d17-11eb-8905-23aca102925b.png)
- Uploaded JSON stored in `localForage`
  - This will be loaded when the vis page is visited. We can then visualise "New Run" and "CI Output"
- Pass `output` data to each of the Vis props


## Additional Information
- Revert Navbar.Brand Link-wrapping in #213 by @Darrekt -- this breaks link highlighting. It's fine to reload the page.
- Make `OutputJSONType` a constant instead of calling `typeof` everyime needed.

## Test Plan

See screenshots.
