### PR TITLE
 [VIS] Add visualisation button from NewRun and CIOutput

### DIFF
--- a/website/src/components/CIOutput/CIOutput.tsx
+++ b/website/src/components/CIOutput/CIOutput.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import outputJSON from '../../output/output.json'
 import outputLog from '../../output/log.txt.json'
 import Artifacts from '../Artifacts/Artifacts'
+import VisualiseButton from '../VisualiseButton/VisualiseButton'
 
 const processedOutputLog = outputLog.join(`\n`)
 
@@ -11,6 +12,9 @@ const CIOutput = () => {
     <h1>CI Output</h1>
     <h3 style={{ marginTop: 24 }}>Artifacts</h3>
     <Artifacts output={outputJSON} logs={processedOutputLog} />
+
+    <h3 style={{ marginTop: 24 }}>Visualise</h3>
+    <VisualiseButton output={outputJSON} />
   </div>
 }
 

--- a/website/src/components/NewRun/NewRun.tsx
+++ b/website/src/components/NewRun/NewRun.tsx
@@ -4,6 +4,7 @@ import { Alert, Button, Row, Col, OverlayTrigger, Tooltip, Form } from 'react-bo
 import { useLoadingState, initialLoadingState } from "../../contexts/loadingState"
 import Artifacts from '../Artifacts/Artifacts'
 import { clearLocalOutput, loadFlags, loadLocalOutput, runGameHelper, setFlagHelper, clearLocalFlags } from './utils'
+import VisualiseButton from "../VisualiseButton/VisualiseButton"
 
 
 type FlagFormProps = {
@@ -155,6 +156,9 @@ const NewRun = () => {
 
         <h3 style={{ marginTop: 24 }}>Artifacts</h3>
         <Artifacts output={output.output} logs={output.logs} />
+
+        <h3 style={{ marginTop: 24 }}>Visualise</h3>
+        <VisualiseButton output={output.output} />
       </div>
     }
   </div>

--- a/website/src/components/VisualiseButton/VisualiseButton.tsx
+++ b/website/src/components/VisualiseButton/VisualiseButton.tsx
@@ -1,0 +1,27 @@
+import { OutputJSONType } from "../../consts/types"
+import React from "react"
+import { Button } from "react-bootstrap"
+import { useLoadingState } from "../../contexts/loadingState"
+import { useHistory } from "react-router-dom"
+import { storeLocalVisOutput } from "../Visualisations/utils"
+import { visualisations } from "../../consts/paths"
+
+const VisualiseButton = (props: { output: OutputJSONType }) => {
+  const [, setLoading] = useLoadingState()
+  const history = useHistory()
+
+  const handleClick = async () => {
+    setLoading({ loading: true, loadingText: `I can show you the world` })
+    const { output } = props
+    await storeLocalVisOutput(output)
+    history.push(visualisations)
+    // don't need to unload as after pushing to vis, there is another loading
+    // instance
+  }
+
+  return <>
+    <Button variant="success" size="lg" onClick={handleClick}>Visualise</Button>
+  </>
+}
+
+export default VisualiseButton


### PR DESCRIPTION
# Summary

As title. The button stores the output JSON into localForage and then brings the user to the vis page. The vis page loads the localForage stuff.

![image](https://user-images.githubusercontent.com/33488131/103461930-c46e0d80-4d19-11eb-82f7-0b7269c63a67.png)
![image](https://user-images.githubusercontent.com/33488131/103461940-cafc8500-4d19-11eb-8afc-55bf9dad4371.png)



## Test Plan

See screenshots