### PR TITLE
[VIS] Fix Navbar.Brand and tr index

### DIFF
--- a/website/src/components/Artifacts/Artifacts.tsx
+++ b/website/src/components/Artifacts/Artifacts.tsx
@@ -54,8 +54,8 @@ const Artifacts = (props: Props) => {
       </thead>
       <tbody>
         {
-          items.map(item =>
-            <tr>
+          items.map((item, idx) =>
+            <tr id={idx.toString()}>
               <td>
                 <span className={styles.code}>{item.fileName}</span>
               </td>

--- a/website/src/containers/AppLayout/Navbar/Navbar.tsx
+++ b/website/src/containers/AppLayout/Navbar/Navbar.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Navbar, Nav } from "react-bootstrap";
-import { Link } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
 import {
   cioutput,
@@ -32,18 +31,17 @@ const AppNavbar = () => {
         onToggle={() => setNavExpanded(!navExpanded)}
         expanded={navExpanded}
       >
-        <Link to="/" className={styles.enlargeOnHover}>
-          <Navbar.Brand className={styles.enlargeOnHover}>
-            <img
-              alt=""
-              src={logo}
-              width="30"
-              height="30"
-              className="d-inline-block align-top"
-            />{" "}
+        {/* lhl2617: DO NOT WRAP BRAND WITH Link AS IT BREAKS OTHER COMPONENTS */}
+        <Navbar.Brand href="/" className={styles.enlargeOnHover}>
+          <img
+            alt=""
+            src={logo}
+            width="30"
+            height="30"
+            className="d-inline-block align-top"
+          />{" "}
             SOMAS 2020
-          </Navbar.Brand>
-        </Link>
+        </Navbar.Brand>
 
         <a
           rel="noopener noreferrer"


### PR DESCRIPTION
# Summary


- Revert Navbar.Brand Link-wrapping in #213 by @Darrekt -- this breaks NavLink highlighting. It's fine to reload the page.
- Add id to tr in Artifacts, it is a list and we need unique ids for elements in a list.

## Test Plan
- NavLink fixed.
- No more console errors complaining for tr id.