### PR TITLE
[VIS] Add AuxInfo with TeamIDs into output.json

### DIFF
--- a/internal/common/shared/shared.go
+++ b/internal/common/shared/shared.go
@@ -11,18 +11,13 @@ import (
 // ClientID is an enum for client IDs
 type ClientID int
 
+// TeamIDs
 const (
-	// Team1 ID
 	Team1 ClientID = iota
-	// Team2 ID
 	Team2
-	// Team3 ID
 	Team3
-	// Team4 ID
 	Team4
-	// Team5 ID
 	Team5
-	// Team6 ID
 	Team6
 )
 

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 			GameStates: gameStates,
 			Config:     gameConfig,
 			GitInfo:    getGitInfo(),
+			AuxInfo:    getAuxInfo(),
 			RunInfo: runInfo{
 				TimeStart:       timeStart,
 				TimeEnd:         timeEnd,

--- a/main_js.go
+++ b/main_js.go
@@ -68,6 +68,7 @@ func RunGame(this js.Value, args []js.Value) interface{} {
 		GameStates: gameStates,
 		Config:     gameConfig,
 		// no git info
+		AuxInfo: getAuxInfo(),
 		RunInfo: runInfo{
 			TimeStart:       timeStart,
 			TimeEnd:         timeEnd,

--- a/shared.go
+++ b/shared.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/SOMAS2020/SOMAS2020/pkg/gitinfo"
 )
 
@@ -17,10 +18,27 @@ type runInfo struct {
 	GOARCH          string
 }
 
+// auxInfo contains other useful auxiliary information, mainly
+// used to help visualisation
+type auxInfo struct {
+	TeamIDs []string
+}
+
+func getAuxInfo() auxInfo {
+	teams := make([]string, len(shared.TeamIDs))
+	for idx, teamID := range shared.TeamIDs {
+		teams[idx] = teamID.String()
+	}
+	return auxInfo{
+		TeamIDs: teams,
+	}
+}
+
 // output represents what is output into the output.json file
 type output struct {
 	Config     config.Config
 	GitInfo    gitinfo.GitInfo
 	RunInfo    runInfo
+	AuxInfo    auxInfo
 	GameStates []gamestate.GameState
 }

--- a/website/src/consts/info.ts
+++ b/website/src/consts/info.ts
@@ -1,0 +1,3 @@
+import outputJSONData from '../output/output.json'
+
+export const teamIDs = outputJSONData.AuxInfo.TeamIDs


### PR DESCRIPTION
# Summary

Vis before this needs to dangerously access game state history (could be empty) to get all TeamIDs. add an AuxInfo field to get all TeamIDs. also define a new exported constant in the website that accesses this.

## Test Plan
`output.json`:
```
...
	"AuxInfo": {
		"TeamIDs": [
			"Team1",
			"Team2",
			"Team3",
			"Team4",
			"Team5",
			"Team6"
		]
	},
...
```