### PR TITLE
IITO: Allow clients to control how much to give in GiftTransactions

### DIFF
--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -53,6 +53,7 @@ type Client interface {
 	GetGiftOffers(receivedRequests shared.GiftRequestDict) shared.GiftOfferDict
 	GetGiftResponses(receivedOffers shared.GiftOfferDict) shared.GiftResponseDict
 	UpdateGiftInfo(receivedResponses shared.GiftResponseDict)
+	DecideGiftAmount(shared.ClientID, shared.Resources) shared.Resources
 
 	//IIGO: COMPULSORY
 	MonitorIIGORole(shared.Role) bool

--- a/internal/common/baseclient/iito.go
+++ b/internal/common/baseclient/iito.go
@@ -75,3 +75,10 @@ func (c *BaseClient) ReceivedGift(received shared.Resources, from shared.ClientI
 	// You can check your updated resources like this:
 	// myResources := c.ServerReadHandle.GetGameState().ClientInfo.Resources
 }
+
+// DecideGiftAmount is executed at the end of each turn and asks clients how much
+// they want to fulfill a gift offer they have made.
+// COMPULSORY, you need to implement this method
+func (c *BaseClient) DecideGiftAmount(toTeam shared.ClientID, giftOffer shared.Resources) shared.Resources {
+	return giftOffer
+}


### PR DESCRIPTION
# Summary
I messed up in #204 and this commit was reverted.

Clients previously was forced to give the amount they promised initially. This isn't quite inline with IITO design. Since giftsTransactions execute at the end of turn, clients state have changed.

Now they are able to specify if they want to fulfil the amount they initially promised or change it.

## Test Plan
Tests all pass.