### PR TITLE
[VIS] Add fake wait in visualise button for stability

### DIFF
--- a/website/src/components/VisualiseButton/VisualiseButton.tsx
+++ b/website/src/components/VisualiseButton/VisualiseButton.tsx
@@ -12,6 +12,10 @@ const VisualiseButton = (props: { output: OutputJSONType }) => {
 
   const handleClick = async () => {
     setLoading({ loading: true, loadingText: `I can show you the world` })
+    
+    // sleep for 100ms for stability
+    await new Promise(r => setTimeout(r, 100));
+    
     const { output } = props
     await storeLocalVisOutput(output)
     history.push(visualisations)


### PR DESCRIPTION
As title. Previously it becomes a bit unstable when the run is a long 'un

## Test plan

Not unstable anymore