### PR TITLE
Patch: prevent clients selecting invalid forage types

### DIFF
--- a/internal/common/shared/forage.go
+++ b/internal/common/shared/forage.go
@@ -28,6 +28,12 @@ func AllForageTypes() []ForageType {
 	return ts
 }
 
+// IsValidForageType checks that a provided type is valid. This can be used to validate foraging
+// decisions, amongst other thigns.
+func IsValidForageType(ft ForageType) bool {
+	return ft < _endForageType && ft >= 0
+}
+
 func (ft ForageType) String() string {
 	strings := [...]string{"DeerForageType", "FishForageType"}
 	if ft >= 0 && int(ft) < len(strings) {

--- a/internal/server/forage.go
+++ b/internal/server/forage.go
@@ -34,17 +34,22 @@ func (s *SOMASServer) runForage() error {
 	}
 
 	for id, decision := range foragingParticipants {
-		forageGroup := forageGroups[decision.Type]
-		err := s.takeResources(id, decision.Contribution, forageGroup.takeResourceReason)
-		if err == nil {
-			if decision.Contribution > 0.0 {
-				(*forageGroup.partyContributions)[id] = decision.Contribution
-			} else {
-				s.logf("%v did not contribute resources and will not participate in this foraging round.", id)
-			}
-			// assign contribution to client ID within appropriate forage group
+
+		if !shared.IsValidForageType(decision.Type) {
+			s.logf("%v client selected invalid forag type in foraging decision: ", decision.Type)
 		} else {
-			s.logf("%v did not have enough resources to participate in foraging", id)
+			forageGroup := forageGroups[decision.Type]
+			err := s.takeResources(id, decision.Contribution, forageGroup.takeResourceReason)
+
+			if err == nil {
+				if decision.Contribution > 0.0 {
+					(*forageGroup.partyContributions)[id] = decision.Contribution // assign contribution to client ID within appropriate forage group
+				} else {
+					s.logf("%v did not contribute resources and will not participate in this foraging round.", id)
+				}
+			} else {
+				s.logf("%v did not have enough resources to participate in foraging", id)
+			}
 		}
 	}
 

--- a/internal/server/forage_test.go
+++ b/internal/server/forage_test.go
@@ -47,6 +47,7 @@ func TestForagingCallsForageUpdate(t *testing.T) {
 	cases := []shared.ForageType{
 		shared.DeerForageType,
 		shared.FishForageType,
+		shared.ForageType(-1), // test extraneous forage type
 	}
 
 	contribs := []shared.Resources{0.0, 1.0, 8.0} // test zero resource contribution first off
@@ -90,13 +91,12 @@ func TestForagingCallsForageUpdate(t *testing.T) {
 					},
 					clientMap: clientMap,
 				}
-
 				err := s.runForage()
 
 				if err != nil {
 					t.Errorf("runForage error: %v", err)
 				}
-				if contrib > 0 {
+				if contrib > 0 && shared.IsValidForageType(tc) { // only check cases where these checks are applicable
 					if !client.forageUpdateCalled {
 						t.Errorf("ForageUpdate was not called")
 					}


### PR DESCRIPTION
# Summary

Implemented a validation check on foraging type supplied in clients' foraging decisions. This addresses issue #240 (at least, the foraging part of it).

## Test Plan

- `forage_test.go` updated to check this.
