### PR TITLE
Fix disaster not reducing agents to 0 correctly.

### DIFF
--- a/internal/server/commonpool.go
+++ b/internal/server/commonpool.go
@@ -12,12 +12,11 @@ func (s *SOMASServer) islandDeplete(cpMitigatedEffect map[shared.ClientID]float6
 		if deduction > 0 {                                         // don't create pointless call if no deduction applicable
 			ci := s.gameState.ClientInfos[clientID]
 			if ci.Resources < deduction {
-				s.logf("[DISASTER]: %v reduced to 0 resources due to disaster damage", clientID)
 				ci.Resources = 0
 			} else {
-				s.logf("[DISASTER]: %v reduced by %v resources due to disaster damage", clientID, deduction)
 				ci.Resources -= deduction
 			}
+			s.logf("[DISASTER]: %v reduced to %v resources due to disaster damage of %v", clientID, ci.Resources, deduction)
 		}
 	}
 }

--- a/internal/server/commonpool.go
+++ b/internal/server/commonpool.go
@@ -10,9 +10,13 @@ func (s *SOMASServer) islandDeplete(cpMitigatedEffect map[shared.ClientID]float6
 	for clientID := range clientMap {
 		deduction := shared.Resources(cpMitigatedEffect[clientID]) // min resources = 0
 		if deduction > 0 {                                         // don't create pointless call if no deduction applicable
-			err := s.takeResources(clientID, deduction, "disaster damage")
-			if err != nil {
-				s.logf("Error taking resources from %v for disaster damage: %v", clientID, err)
+			ci := s.gameState.ClientInfos[clientID]
+			if ci.Resources < deduction {
+				s.logf("[DISASTER]: %v reduced to 0 resources due to disaster damage", clientID)
+				ci.Resources = 0
+			} else {
+				s.logf("[DISASTER]: %v reduced by %v resources due to disaster damage", clientID, deduction)
+				ci.Resources -= deduction
 			}
 		}
 	}


### PR DESCRIPTION
# Summary
If the disaster wanted to take more resources than what the client had. Disaster would not reduce the client resources to 0. Instead it would skip over the agent. 

![image](https://user-images.githubusercontent.com/44125446/103492245-6b899c80-4e21-11eb-9400-0b9adfb7f9ce.png)