### PR TITLE
[INFRA/CORE] Make certain config (selectively) visible to client (#263)

### DIFF
--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/disasters"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/roles"
@@ -67,6 +68,7 @@ type Client interface {
 // ServerReadHandle is a read-only handle to the game server, used for client to get up-to-date gamestate
 type ServerReadHandle interface {
 	GetGameState() gamestate.ClientGameState
+	GetGameConfig() config.ClientConfig
 }
 
 // NewClient produces a new client with the BaseClient already implemented.

--- a/internal/common/config/clientconfig.go
+++ b/internal/common/config/clientconfig.go
@@ -1,4 +1,41 @@
 package config
 
+import "github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+
 // ClientConfig contains config information visible to clients.
-type ClientConfig struct{}
+type ClientConfig struct {
+	CostOfLiving                shared.Resources
+	MinimumResourceThreshold    shared.Resources
+	MaxCriticalConsecutiveTurns uint
+	DisasterConfig              ClientDisasterConfig
+}
+
+// ClientDisasterConfig contains disaster config information visible to clients.
+type ClientDisasterConfig struct {
+	MagnitudeResourceMultiplier SelectivelyVisibleFloat64
+	CommonpoolThreshold         SelectivelyVisibleResources
+}
+
+// GetClientConfig gets ClientConfig.
+func (c Config) GetClientConfig() ClientConfig {
+	return ClientConfig{
+		CostOfLiving:                c.CostOfLiving,
+		MinimumResourceThreshold:    c.MinimumResourceThreshold,
+		MaxCriticalConsecutiveTurns: c.MaxCriticalConsecutiveTurns,
+		DisasterConfig:              c.DisasterConfig.GetClientDisasterConfig(),
+	}
+}
+
+// GetClientDisasterConfig gets ClientDisasterConfig
+func (c DisasterConfig) GetClientDisasterConfig() ClientDisasterConfig {
+	return ClientDisasterConfig{
+		MagnitudeResourceMultiplier: getSelectivelyVisibleFloat64(
+			c.MagnitudeResourceMultiplier,
+			c.MagnitudeResourceMultiplierVisible,
+		),
+		CommonpoolThreshold: getSelectivelyVisibleResources(
+			c.CommonpoolThreshold,
+			c.CommonpoolThresholdVisible,
+		),
+	}
+}

--- a/internal/common/config/clientconfig.go
+++ b/internal/common/config/clientconfig.go
@@ -1,0 +1,4 @@
+package config
+
+// ClientConfig contains config information visible to clients.
+type ClientConfig struct{}

--- a/internal/common/config/clientconfig.go
+++ b/internal/common/config/clientconfig.go
@@ -12,8 +12,7 @@ type ClientConfig struct {
 
 // ClientDisasterConfig contains disaster config information visible to clients.
 type ClientDisasterConfig struct {
-	MagnitudeResourceMultiplier SelectivelyVisibleFloat64
-	CommonpoolThreshold         SelectivelyVisibleResources
+	CommonpoolThreshold SelectivelyVisibleResources
 }
 
 // GetClientConfig gets ClientConfig.
@@ -29,10 +28,6 @@ func (c Config) GetClientConfig() ClientConfig {
 // GetClientDisasterConfig gets ClientDisasterConfig
 func (c DisasterConfig) GetClientDisasterConfig() ClientDisasterConfig {
 	return ClientDisasterConfig{
-		MagnitudeResourceMultiplier: getSelectivelyVisibleFloat64(
-			c.MagnitudeResourceMultiplier,
-			c.MagnitudeResourceMultiplierVisible,
-		),
 		CommonpoolThreshold: getSelectivelyVisibleResources(
 			c.CommonpoolThreshold,
 			c.CommonpoolThresholdVisible,

--- a/internal/common/config/clientconfig_test.go
+++ b/internal/common/config/clientconfig_test.go
@@ -20,11 +20,9 @@ func TestGetClientConfig(t *testing.T) {
 				MaxCriticalConsecutiveTurns: 3,
 				MaxSeasons:                  4, // not visible
 				DisasterConfig: DisasterConfig{
-					MagnitudeResourceMultiplier:        5,
-					MagnitudeResourceMultiplierVisible: true,
-					CommonpoolThreshold:                6,
-					CommonpoolThresholdVisible:         true,
-					GlobalProb:                         4.20, // not visible
+					CommonpoolThreshold:        6,
+					CommonpoolThresholdVisible: true,
+					GlobalProb:                 4.20, // not visible
 				},
 			},
 			want: ClientConfig{
@@ -32,10 +30,6 @@ func TestGetClientConfig(t *testing.T) {
 				MinimumResourceThreshold:    2,
 				MaxCriticalConsecutiveTurns: 3,
 				DisasterConfig: ClientDisasterConfig{
-					MagnitudeResourceMultiplier: SelectivelyVisibleFloat64{
-						Value: 5,
-						Valid: true,
-					},
 					CommonpoolThreshold: SelectivelyVisibleResources{
 						Value: 6,
 						Valid: true,
@@ -51,11 +45,9 @@ func TestGetClientConfig(t *testing.T) {
 				MaxCriticalConsecutiveTurns: 3,
 				MaxSeasons:                  4, // not visible
 				DisasterConfig: DisasterConfig{
-					MagnitudeResourceMultiplier:        5,
-					MagnitudeResourceMultiplierVisible: false,
-					CommonpoolThreshold:                6,
-					CommonpoolThresholdVisible:         false,
-					GlobalProb:                         4.20, // not visible
+					CommonpoolThreshold:        6,
+					CommonpoolThresholdVisible: false,
+					GlobalProb:                 4.20, // not visible
 				},
 			},
 			want: ClientConfig{
@@ -63,9 +55,6 @@ func TestGetClientConfig(t *testing.T) {
 				MinimumResourceThreshold:    2,
 				MaxCriticalConsecutiveTurns: 3,
 				DisasterConfig: ClientDisasterConfig{
-					MagnitudeResourceMultiplier: SelectivelyVisibleFloat64{
-						Valid: false,
-					},
 					CommonpoolThreshold: SelectivelyVisibleResources{
 						Valid: false,
 					},

--- a/internal/common/config/clientconfig_test.go
+++ b/internal/common/config/clientconfig_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Tests GetClientDisasterConfig too
+func TestGetClientConfig(t *testing.T) {
+	cases := []struct {
+		name   string
+		config Config
+		want   ClientConfig
+	}{
+		{
+			name: "all visible",
+			config: Config{
+				CostOfLiving:                1,
+				MinimumResourceThreshold:    2,
+				MaxCriticalConsecutiveTurns: 3,
+				MaxSeasons:                  4, // not visible
+				DisasterConfig: DisasterConfig{
+					MagnitudeResourceMultiplier:        5,
+					MagnitudeResourceMultiplierVisible: true,
+					CommonpoolThreshold:                6,
+					CommonpoolThresholdVisible:         true,
+					GlobalProb:                         4.20, // not visible
+				},
+			},
+			want: ClientConfig{
+				CostOfLiving:                1,
+				MinimumResourceThreshold:    2,
+				MaxCriticalConsecutiveTurns: 3,
+				DisasterConfig: ClientDisasterConfig{
+					MagnitudeResourceMultiplier: SelectivelyVisibleFloat64{
+						Value: 5,
+						Valid: true,
+					},
+					CommonpoolThreshold: SelectivelyVisibleResources{
+						Value: 6,
+						Valid: true,
+					},
+				},
+			},
+		},
+		{
+			name: "all selectively visible invisible",
+			config: Config{
+				CostOfLiving:                1,
+				MinimumResourceThreshold:    2,
+				MaxCriticalConsecutiveTurns: 3,
+				MaxSeasons:                  4, // not visible
+				DisasterConfig: DisasterConfig{
+					MagnitudeResourceMultiplier:        5,
+					MagnitudeResourceMultiplierVisible: false,
+					CommonpoolThreshold:                6,
+					CommonpoolThresholdVisible:         false,
+					GlobalProb:                         4.20, // not visible
+				},
+			},
+			want: ClientConfig{
+				CostOfLiving:                1,
+				MinimumResourceThreshold:    2,
+				MaxCriticalConsecutiveTurns: 3,
+				DisasterConfig: ClientDisasterConfig{
+					MagnitudeResourceMultiplier: SelectivelyVisibleFloat64{
+						Valid: false,
+					},
+					CommonpoolThreshold: SelectivelyVisibleResources{
+						Valid: false,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.config.GetClientConfig()
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -74,14 +74,13 @@ type FishingConfig struct {
 
 // DisasterConfig captures disaster-specific config
 type DisasterConfig struct {
-	XMin, XMax, YMin, YMax             shared.Coordinate     // [min, max] x,y bounds of archipelago (bounds for possible disaster)
-	GlobalProb                         float64               // Bernoulli 'p' param. Chance of a disaster occurring
-	SpatialPDFType                     shared.SpatialPDFType // Set x,y prob. distribution of the disaster's epicentre (more post MVP)
-	MagnitudeLambda                    float64               // Exponential rate param for disaster magnitude
-	MagnitudeResourceMultiplier        float64               // multiplier to map disaster magnitude to CP resource deductions
-	MagnitudeResourceMultiplierVisible bool                  // whether MagnitudeResourceMultiplier is visible to clients
-	CommonpoolThreshold                shared.Resources      // threshold for min CP resources for disaster mitigation
-	CommonpoolThresholdVisible         bool                  // whether CommonpoolThreshold is visible to clients
+	XMin, XMax, YMin, YMax      shared.Coordinate     // [min, max] x,y bounds of archipelago (bounds for possible disaster)
+	GlobalProb                  float64               // Bernoulli 'p' param. Chance of a disaster occurring
+	SpatialPDFType              shared.SpatialPDFType // Set x,y prob. distribution of the disaster's epicentre (more post MVP)
+	MagnitudeLambda             float64               // Exponential rate param for disaster magnitude
+	MagnitudeResourceMultiplier float64               // multiplier to map disaster magnitude to CP resource deductions
+	CommonpoolThreshold         shared.Resources      // threshold for min CP resources for disaster mitigation
+	CommonpoolThresholdVisible  bool                  // whether CommonpoolThreshold is visible to clients
 }
 
 type IIGOConfig struct {

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -74,12 +74,14 @@ type FishingConfig struct {
 
 // DisasterConfig captures disaster-specific config
 type DisasterConfig struct {
-	XMin, XMax, YMin, YMax      shared.Coordinate     // [min, max] x,y bounds of archipelago (bounds for possible disaster)
-	GlobalProb                  float64               // Bernoulli 'p' param. Chance of a disaster occurring
-	SpatialPDFType              shared.SpatialPDFType // Set x,y prob. distribution of the disaster's epicentre (more post MVP)
-	MagnitudeLambda             float64               // Exponential rate param for disaster magnitude
-	MagnitudeResourceMultiplier float64               // multiplier to map disaster magnitude to CP resource deductions
-	CommonpoolThreshold         shared.Resources      // threshold for min CP resources for disaster mitigation
+	XMin, XMax, YMin, YMax             shared.Coordinate     // [min, max] x,y bounds of archipelago (bounds for possible disaster)
+	GlobalProb                         float64               // Bernoulli 'p' param. Chance of a disaster occurring
+	SpatialPDFType                     shared.SpatialPDFType // Set x,y prob. distribution of the disaster's epicentre (more post MVP)
+	MagnitudeLambda                    float64               // Exponential rate param for disaster magnitude
+	MagnitudeResourceMultiplier        float64               // multiplier to map disaster magnitude to CP resource deductions
+	MagnitudeResourceMultiplierVisible bool                  // whether MagnitudeResourceMultiplier is visible to clients
+	CommonpoolThreshold                shared.Resources      // threshold for min CP resources for disaster mitigation
+	CommonpoolThresholdVisible         bool                  // whether CommonpoolThreshold is visible to clients
 }
 
 type IIGOConfig struct {

--- a/internal/common/config/helpertypes.go
+++ b/internal/common/config/helpertypes.go
@@ -1,0 +1,37 @@
+package config
+
+import "github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+
+// SelectivelyVisibleFloat64 represents a wrapped float64 whose value is valid only if the Valid flag is set to true
+type SelectivelyVisibleFloat64 struct {
+	Value float64
+	Valid bool
+}
+
+func getSelectivelyVisibleFloat64(value float64, valid bool) SelectivelyVisibleFloat64 {
+	var res float64
+	if valid {
+		res = value
+	}
+	return SelectivelyVisibleFloat64{
+		Value: res,
+		Valid: valid,
+	}
+}
+
+// SelectivelyVisibleResources represents a wrapped Resources whose value is valid only if the Valid flag is set to true
+type SelectivelyVisibleResources struct {
+	Value shared.Resources
+	Valid bool
+}
+
+func getSelectivelyVisibleResources(value shared.Resources, valid bool) SelectivelyVisibleResources {
+	var res shared.Resources
+	if valid {
+		res = value
+	}
+	return SelectivelyVisibleResources{
+		Value: res,
+		Valid: valid,
+	}
+}

--- a/internal/common/config/helpertypes_test.go
+++ b/internal/common/config/helpertypes_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+)
+
+func TestGetSelectivelyVisibleFloat64(t *testing.T) {
+	origVal := float64(69)
+	cases := []struct {
+		name  string
+		valid bool
+		want  SelectivelyVisibleFloat64
+	}{
+		{
+			name:  "valid",
+			valid: true,
+			want: SelectivelyVisibleFloat64{
+				Value: origVal,
+				Valid: true,
+			},
+		},
+		{
+			name:  "not valid",
+			valid: false,
+			want: SelectivelyVisibleFloat64{
+				Value: 0,
+				Valid: false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getSelectivelyVisibleFloat64(origVal, tc.valid)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestGetSelectivelyVisibleResources(t *testing.T) {
+	origVal := shared.Resources(69)
+	cases := []struct {
+		name  string
+		valid bool
+		want  SelectivelyVisibleResources
+	}{
+		{
+			name:  "valid",
+			valid: true,
+			want: SelectivelyVisibleResources{
+				Value: origVal,
+				Valid: true,
+			},
+		},
+		{
+			name:  "not valid",
+			valid: false,
+			want: SelectivelyVisibleResources{
+				Value: shared.Resources(0),
+				Valid: false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getSelectivelyVisibleResources(origVal, tc.valid)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,8 +123,7 @@ func (s *SOMASServer) logf(format string, a ...interface{}) {
 	log.Printf("[SERVER]: %v", fmt.Sprintf(format, a...))
 }
 
-// ServerForClient is a reference to the server for particular client. It is
-// meant as an instance of baseclient.ServerReadHandle
+// ServerForClient is a reference to the server for particular client. It implements baseclient.ServerReadHandle
 type ServerForClient struct {
 	clientID shared.ClientID
 	server   *SOMASServer
@@ -134,4 +133,9 @@ type ServerForClient struct {
 // s.server
 func (s ServerForClient) GetGameState() gamestate.ClientGameState {
 	return s.server.gameState.GetClientGameStateCopy(s.clientID)
+}
+
+// GetGameConfig returns ClientConfig which is a subset of the entire Config that is visible to clients.
+func (s ServerForClient) GetGameConfig() config.ClientConfig {
+	return config.ClientConfig{}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,5 +137,5 @@ func (s ServerForClient) GetGameState() gamestate.ClientGameState {
 
 // GetGameConfig returns ClientConfig which is a subset of the entire Config that is visible to clients.
 func (s ServerForClient) GetGameConfig() config.ClientConfig {
-	return config.ClientConfig{}
+	return s.server.gameConfig.GetClientConfig()
 }

--- a/params.go
+++ b/params.go
@@ -184,10 +184,20 @@ var (
 		500,
 		"Multiplier to map disaster magnitude to CP resource deductions",
 	)
+	disasterMagnitudeResourceMultiplierVisible = flag.Bool(
+		"disasterMagnitudeResourceMultiplierVisible",
+		false,
+		"Whether disasterMagnitudeResourceMultiplierVisible is visible to agents",
+	)
 	disasterCommonpoolThreshold = flag.Float64(
 		"disasterCommonpoolThreshold",
 		50,
 		"Common pool threshold value for disaster to be mitigated",
+	)
+	disasterCommonpoolThresholdVisible = flag.Bool(
+		"disasterCommonpoolThresholdVisible",
+		false,
+		"Whether disasterCommonpoolThreshold is visible to agents",
 	)
 
 	// config.IIGOConfig - Executive branch
@@ -340,7 +350,6 @@ func parseConfig() (config.Config, error) {
 		DistributionStrategy:  parsedForagingDeerDistributionStrategy,
 		ThetaCritical:         *foragingDeerThetaCritical,
 		ThetaMax:              *foragingDeerThetaMax,
-
 		MaxDeerPopulation:     parseDeerMaxPopulation,
 		DeerGrowthCoefficient: *foragingDeerGrowthCoefficient,
 	}
@@ -359,15 +368,17 @@ func parseConfig() (config.Config, error) {
 		FishingConfig:  fishingConf,
 	}
 	disasterConf := config.DisasterConfig{
-		XMin:                        *disasterXMin,
-		XMax:                        *disasterXMax,
-		YMin:                        *disasterYMin,
-		YMax:                        *disasterYMax,
-		GlobalProb:                  *disasterGlobalProb,
-		SpatialPDFType:              parsedDisasterSpatialPDFType,
-		MagnitudeLambda:             *disasterMagnitudeLambda,
-		MagnitudeResourceMultiplier: *disasterMagnitudeResourceMultiplier,
-		CommonpoolThreshold:         shared.Resources(*disasterCommonpoolThreshold),
+		XMin:                               *disasterXMin,
+		XMax:                               *disasterXMax,
+		YMin:                               *disasterYMin,
+		YMax:                               *disasterYMax,
+		GlobalProb:                         *disasterGlobalProb,
+		SpatialPDFType:                     parsedDisasterSpatialPDFType,
+		MagnitudeLambda:                    *disasterMagnitudeLambda,
+		MagnitudeResourceMultiplier:        *disasterMagnitudeResourceMultiplier,
+		MagnitudeResourceMultiplierVisible: *disasterMagnitudeResourceMultiplierVisible,
+		CommonpoolThreshold:                shared.Resources(*disasterCommonpoolThreshold),
+		CommonpoolThresholdVisible:         *disasterCommonpoolThresholdVisible,
 	}
 
 	iigoConf := config.IIGOConfig{

--- a/params.go
+++ b/params.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	//config.Config
+	// config.Config
 	maxSeasons = flag.Uint(
 		"maxSeasons",
 		10,
@@ -48,6 +48,8 @@ var (
 		3,
 		"The maximum consecutive turns an island can be in the critical state.",
 	)
+
+	// config.ForagingConfig.DeerHuntConfig
 	foragingDeerMaxPerHunt = flag.Uint(
 		"foragingMaxDeerPerHunt",
 		4,
@@ -103,6 +105,8 @@ var (
 		0.2,
 		"Scaling parameter used in the population model. Larger coeff => deer pop. regenerates faster.",
 	)
+
+	// config.ForagingConfig.FishingConfig
 	foragingFishMaxPerHunt = flag.Uint(
 		"foragingMaxFishPerHunt",
 		6,
@@ -367,7 +371,6 @@ func parseConfig() (config.Config, error) {
 	}
 
 	iigoConf := config.IIGOConfig{
-
 		// Executive branch
 		GetRuleForSpeakerActionCost:        shared.Resources(*iigoGetRuleForSpeakerActionCost),
 		BroadcastTaxationActionCost:        shared.Resources(*iigoBroadcastTaxationActionCost),

--- a/params.go
+++ b/params.go
@@ -184,11 +184,6 @@ var (
 		500,
 		"Multiplier to map disaster magnitude to CP resource deductions",
 	)
-	disasterMagnitudeResourceMultiplierVisible = flag.Bool(
-		"disasterMagnitudeResourceMultiplierVisible",
-		false,
-		"Whether disasterMagnitudeResourceMultiplierVisible is visible to agents",
-	)
 	disasterCommonpoolThreshold = flag.Float64(
 		"disasterCommonpoolThreshold",
 		50,
@@ -368,17 +363,16 @@ func parseConfig() (config.Config, error) {
 		FishingConfig:  fishingConf,
 	}
 	disasterConf := config.DisasterConfig{
-		XMin:                               *disasterXMin,
-		XMax:                               *disasterXMax,
-		YMin:                               *disasterYMin,
-		YMax:                               *disasterYMax,
-		GlobalProb:                         *disasterGlobalProb,
-		SpatialPDFType:                     parsedDisasterSpatialPDFType,
-		MagnitudeLambda:                    *disasterMagnitudeLambda,
-		MagnitudeResourceMultiplier:        *disasterMagnitudeResourceMultiplier,
-		MagnitudeResourceMultiplierVisible: *disasterMagnitudeResourceMultiplierVisible,
-		CommonpoolThreshold:                shared.Resources(*disasterCommonpoolThreshold),
-		CommonpoolThresholdVisible:         *disasterCommonpoolThresholdVisible,
+		XMin:                        *disasterXMin,
+		XMax:                        *disasterXMax,
+		YMin:                        *disasterYMin,
+		YMax:                        *disasterYMax,
+		GlobalProb:                  *disasterGlobalProb,
+		SpatialPDFType:              parsedDisasterSpatialPDFType,
+		MagnitudeLambda:             *disasterMagnitudeLambda,
+		MagnitudeResourceMultiplier: *disasterMagnitudeResourceMultiplier,
+		CommonpoolThreshold:         shared.Resources(*disasterCommonpoolThreshold),
+		CommonpoolThresholdVisible:  *disasterCommonpoolThresholdVisible,
 	}
 
 	iigoConf := config.IIGOConfig{


### PR DESCRIPTION
# Summary

#263 . 
- Always visible items are put into `ClientGameConfig`. 
- Selectively ones are put into it under wrapped types such as `SelectivelyVisibleResources`.
- Flags added to make selectively visible values (in)visible

## Test Plan

- Unit tests added
- Changed `func (c *BaseClient) StartOfTurn() {}` to
```
func (c *BaseClient) StartOfTurn() {
	c.Logf("%#v", c.ServerReadHandle.GetGameConfig())
	panic("STOP")
}
```
output in `go run .`
```
...
2021/01/04 14:35:10 [Team6]: config.ClientConfig{CostOfLiving:0, MinimumResourceThreshold:0, MaxCriticalConsecutiveTurns:0x0, DisasterConfig:config.ClientDisasterConfig{MagnitudeResourceMultiplier:config.SelectivelyVisibleFloat64{Value:0, Valid:false}, CommonpoolThreshold:config.SelectivelyVisibleResources{Value:0, Valid:false}}}
...
```
output in `go run . -disasterCommonpoolThresholdVisible true`
```
...
2021/01/04 14:37:36 [Team6]: config.ClientConfig{CostOfLiving:10, MinimumResourceThreshold:5, MaxCriticalConsecutiveTurns:0x3, DisasterConfig:config.ClientDisasterConfig{MagnitudeResourceMultiplier:config.SelectivelyVisibleFloat64{Value:0, Valid:false}, CommonpoolThreshold:config.SelectivelyVisibleResources{Value:50, Valid:true}}}
...
```

NB these tests ran at `85b551d` but behaviour is same for subsequent changes.