### PR TITLE
[INFRA/CORE] Adding Budget Information to ClientGameState

### DIFF
--- a/internal/common/gamestate/clientgamestate.go
+++ b/internal/common/gamestate/clientgamestate.go
@@ -23,4 +23,7 @@ type ClientGameState struct {
 	SpeakerID   shared.ClientID
 	JudgeID     shared.ClientID
 	PresidentID shared.ClientID
+
+	// IIGO roles budget (initialised in orchestration.go)
+	IIGORolesBudget map[shared.Role]shared.Resources
 }

--- a/internal/common/gamestate/gamestate.go
+++ b/internal/common/gamestate/gamestate.go
@@ -71,6 +71,7 @@ func (g *GameState) GetClientGameStateCopy(id shared.ClientID) ClientGameState {
 		SpeakerID:          g.SpeakerID,
 		JudgeID:            g.JudgeID,
 		PresidentID:        g.PresidentID,
+		IIGORolesBudget:    copyRolesBudget(g.IIGORolesBudget),
 	}
 }
 

--- a/internal/common/gamestate/gamestate_test.go
+++ b/internal/common/gamestate/gamestate_test.go
@@ -39,8 +39,8 @@ func TestGetClientGameStateCopy(t *testing.T) {
 				CriticalConsecutiveTurnsCounter: 2,
 			},
 		},
-
-		CommonPool: 20,
+		IIGORolesBudget: map[shared.Role]shared.Resources{},
+		CommonPool:      20,
 	}
 
 	lifeStatuses := map[shared.ClientID]shared.ClientLifeStatus{
@@ -60,6 +60,7 @@ func TestGetClientGameStateCopy(t *testing.T) {
 				ClientLifeStatuses: lifeStatuses,
 				CommonPool:         gameState.CommonPool,
 				IslandLocations:    gameState.Environment.Geography.Islands,
+				IIGORolesBudget:    map[shared.Role]shared.Resources{},
 			}
 
 			gotClientGS := gameState.GetClientGameStateCopy(tc)


### PR DESCRIPTION
# Summary

As title. Adding IIGO role budget information to ClientGameState so that islands can access this information.

## Additional Information

N/A

## Test Plan

N/A
