### PR TITLE
[INFRA/IIGO] Removed re-election, added IIGO monitoring cache to gamestate for logging

### DIFF
--- a/internal/common/gamestate/gamestate.go
+++ b/internal/common/gamestate/gamestate.go
@@ -35,6 +35,9 @@ type GameState struct {
 	// IIGO turns in power (incremented and set by monitoring)
 	IIGOTurnsInPower map[shared.Role]uint
 
+	//IIGO Role Action Cache
+	IIGOCache []shared.Accountability
+
 	// IITO Transactions
 	IITOTransactions map[shared.ClientID]shared.GiftResponseDict
 
@@ -57,6 +60,7 @@ func (g GameState) Copy() GameState {
 	ret.IIGOHistory = copyIIGOHistory(g.IIGOHistory)
 	ret.IIGORolesBudget = copyRolesBudget(g.IIGORolesBudget)
 	ret.IIGOTurnsInPower = copyTurnsInPower(g.IIGOTurnsInPower)
+	ret.IIGOCache = copyIIGOCache(g.IIGOCache)
 	return ret
 }
 
@@ -80,6 +84,12 @@ func (g *GameState) GetClientGameStateCopy(id shared.ClientID) ClientGameState {
 		IIGORolesBudget:    copyRolesBudget(g.IIGORolesBudget),
 		IIGOTurnsInPower:   copyTurnsInPower(g.IIGOTurnsInPower),
 	}
+}
+
+func copyIIGOCache(c []shared.Accountability) []shared.Accountability {
+	ret := make([]shared.Accountability, len(c))
+	copy(ret, c)
+	return ret
 }
 
 func copyClientInfos(m map[shared.ClientID]ClientInfo) map[shared.ClientID]ClientInfo {

--- a/internal/server/iigointernal/orchestration.go
+++ b/internal/server/iigointernal/orchestration.go
@@ -225,6 +225,8 @@ func RunIIGO(g *gamestate.GameState, clientMap *map[shared.ClientID]baseclient.C
 	speakerMonitored := monitoring.monitorRole(g, iigoClients[g.JudgeID])
 	presidentMonitored := monitoring.monitorRole(g, iigoClients[g.SpeakerID])
 	judgeMonitored := monitoring.monitorRole(g, iigoClients[g.PresidentID])
+	//Save to gameState and clear
+	g.IIGOCache = monitoring.internalIIGOCache
 	monitoring.clearCache()
 
 	// TODO:- at the moment, these are action (and cost resources) but should they?

--- a/internal/server/iigointernal/orchestration.go
+++ b/internal/server/iigointernal/orchestration.go
@@ -222,9 +222,9 @@ func RunIIGO(g *gamestate.GameState, clientMap *map[shared.ClientID]baseclient.C
 		return false, "Cannot pay IIGO salary"
 	}
 
-	speakerMonitored := monitoring.monitorRole(g, iigoClients[g.JudgeID])
 	presidentMonitored := monitoring.monitorRole(g, iigoClients[g.SpeakerID])
 	judgeMonitored := monitoring.monitorRole(g, iigoClients[g.PresidentID])
+	speakerMonitored := monitoring.monitorRole(g, iigoClients[g.JudgeID])
 	//Save to gameState and clear
 	g.IIGOCache = monitoring.internalIIGOCache
 	monitoring.clearCache()


### PR DESCRIPTION
Removed re-elections to reduce IIGO complexity. Monitoring cache is now saved across turns so now if a role is caught cheating in the election, (if in play) election rules will oblige the responsible role to hold an election for the no-goodie-election-fraud-island in the next turn (instead of the current). 

Added IIGOCache to the gamestate (updates in monitoring before the cache is cleared)

Changed the order of monitoring so now the president's and judge's monitoring actions are monitored. The speakers monitoring is not (that ok, we said this would be the case from the getgo, the other two are just a happy accident) 