### PR TITLE
[VIS] new run UI change

### DIFF
--- a/website/src/components/NewRun/NewRun.tsx
+++ b/website/src/components/NewRun/NewRun.tsx
@@ -139,7 +139,7 @@ const NewRun = () => {
       </div>
     }
     {
-      flags &&
+      flags && (output === undefined) &&
       <div>
         <Button variant="danger" size="lg" onClick={resetFlags} disabled={output !== undefined} style={{ marginTop: 24 }}>Reset Flags</Button>
         <Row style={{ marginLeft: `5vw`, marginRight: `5vw`, marginTop: 48, marginBottom: 48 }}>

--- a/website/src/components/NewRun/NewRun.tsx
+++ b/website/src/components/NewRun/NewRun.tsx
@@ -126,6 +126,13 @@ const NewRun = () => {
     <h1>New Run</h1>
 
     {
+      runError &&
+      <Alert variant="danger" onClose={() => setRunError(undefined)} dismissible className="custom-alert">
+        <Alert.Heading>Oh reeeeeeeeee!</Alert.Heading>
+        <p>{runError}</p>
+      </Alert>
+    }
+    {
       !output &&
       <div>
         <Button variant="success" size="lg" onClick={run} disabled={flags === undefined}>Run</Button>
@@ -139,13 +146,6 @@ const NewRun = () => {
           {getFlagForms(flags)}
         </Row>
       </div>
-    }
-    {
-      runError &&
-      <Alert variant="danger" onClose={() => setRunError(undefined)} dismissible className="custom-alert">
-        <Alert.Heading>Oh reeeeeeeeee!</Alert.Heading>
-        <p>{runError}</p>
-      </Alert>
     }
     {
       output &&


### PR DESCRIPTION
# Summary

Closes #315 
Moved error to top of page and hide flags when output is available.

After run: 
![image](https://user-images.githubusercontent.com/44067693/103908076-fe645880-50f9-11eb-801b-8e329757de25.png)  

Before run: 
![image](https://user-images.githubusercontent.com/44067693/103908112-0cb27480-50fa-11eb-935f-7ebca4ce7f1e.png)  

Error: 
![image](https://user-images.githubusercontent.com/44067693/103908172-1a67fa00-50fa-11eb-8b8b-0d46baa37fc8.png)


## Additional Information

NA

## Test Plan

See screenshots
