### PR TITLE
[VIS/WASM] Try to recover in RunGame if panicked

### DIFF
--- a/website/.eslintrc
+++ b/website/.eslintrc
@@ -34,7 +34,9 @@
         "tsx": "never"
       }
     ],
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", {
+      "endOfLine":"auto"
+    }],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "react/jsx-filename-extension": [

--- a/website/src/wasmAPI.tsx
+++ b/website/src/wasmAPI.tsx
@@ -82,6 +82,12 @@ export const runGame = async (flags: Flag[]): Promise<RunGameReturnType> => {
 
   const result = runGameWASM(args)
   if (result.error.length > 0) {
+    if (result.output) {
+      console.debug(result.output)
+    }
+    if (result.logs) {
+      console.debug(result.logs)
+    }
     throw new Error(result.error)
   }
   if (result.output === undefined || result.logs === undefined) {


### PR DESCRIPTION
# Summary

When the WASM instance panics it just shows stuff like #327. Add a recover and handle the panic.

## Additional Info
- Change prettier settings to account for windows crlf issue

## Test Plan

Try to repo as per #327. Output:

![image](https://user-images.githubusercontent.com/33488131/103937892-55c9ef00-5121-11eb-8b69-3fa7c512db09.png)
