### PR TITLE
[INFRA/CORE] Add --output argument for output folder

### DIFF
--- a/params.go
+++ b/params.go
@@ -9,6 +9,12 @@ import (
 )
 
 var (
+	// output folder
+	outputFolderName = flag.String(
+		"output",
+		"output",
+		"The relative path (to the current working directory) to store output.json and logs in.",
+	)
 	// config.Config
 	maxSeasons = flag.Uint(
 		"maxSeasons",


### PR DESCRIPTION
# Summary
Required for #335 . 

## Additional Info
- Refactor functions in `main.go`
- Use `log.Fatalf` in place of `log.Printf` then `os.exit(1)`

## Test plan
`go run . --output abc` OK
`go run . --output output/abc` OK