### PR TITLE
[INFRA/CORE] Move output flag to non-WASM file

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,16 @@ import (
 const outputJSONFileName = "output.json"
 const outputLogFileName = "log.txt"
 
+// non-WASM flags.
+// see `params.go` for shared flags.
+var (
+	outputFolderName = flag.String(
+		"output",
+		"output",
+		"The relative path (to the current working directory) to store output.json and logs in.",
+	)
+)
+
 func main() {
 	timeStart := time.Now()
 	var err error

--- a/params.go
+++ b/params.go
@@ -9,12 +9,6 @@ import (
 )
 
 var (
-	// output folder
-	outputFolderName = flag.String(
-		"output",
-		"output",
-		"The relative path (to the current working directory) to store output.json and logs in.",
-	)
 	// config.Config
 	maxSeasons = flag.Uint(
 		"maxSeasons",


### PR DESCRIPTION
# Summary

Before this change the WASM compilation also contains the `output` flag intended for bare metal runs only.
Move it to `main.go` which is only compiled for non-WASM.


## Test Plan

- CLI still works as before
- Website no longer has `output` flag.