### PR TITLE
Updated ForageUpdate() to include number of deer/fish caught

### DIFF
--- a/internal/clients/team1/foraging.go
+++ b/internal/clients/team1/foraging.go
@@ -213,7 +213,7 @@ func (c *client) DecideForage() (shared.ForageDecision, error) {
 	}
 }
 
-func (c *client) ForageUpdate(forageDecision shared.ForageDecision, revenue shared.Resources) {
+func (c *client) ForageUpdate(forageDecision shared.ForageDecision, revenue shared.Resources, numberCaught uint) {
 	c.forageHistory[forageDecision.Type] = append(c.forageHistory[forageDecision.Type], ForageOutcome{
 		contribution: forageDecision.Contribution,
 		revenue:      revenue,

--- a/internal/clients/team6/foraging.go
+++ b/internal/clients/team6/foraging.go
@@ -97,7 +97,7 @@ func (c *client) DecideForage() (shared.ForageDecision, error) {
 
 }
 
-func (c *client) ForageUpdate(forageDecision shared.ForageDecision, outcome shared.Resources) {
+func (c *client) ForageUpdate(forageDecision shared.ForageDecision, outcome shared.Resources, numberCaught uint) {
 	currTurn := c.ServerReadHandle.GetGameState().Turn
 
 	c.forageHistory[forageDecision.Type] =

--- a/internal/common/baseclient/baseclient.go
+++ b/internal/common/baseclient/baseclient.go
@@ -39,7 +39,7 @@ type Client interface {
 
 	//Foraging
 	DecideForage() (shared.ForageDecision, error)
-	ForageUpdate(shared.ForageDecision, shared.Resources)
+	ForageUpdate(shared.ForageDecision, shared.Resources, uint)
 
 	//Disasters
 	DisasterNotification(disasters.DisasterReport, disasters.DisasterEffects)

--- a/internal/common/baseclient/forage.go
+++ b/internal/common/baseclient/forage.go
@@ -17,4 +17,7 @@ func (c *BaseClient) DecideForage() (shared.ForageDecision, error) {
 	}, nil
 }
 
-func (c *BaseClient) ForageUpdate(shared.ForageDecision, shared.Resources) {}
+// ForageUpdate is called by the server upon completion of a foraging session. This handler can be used by clients to
+// analyse their returns - resources returned to them, as well as number of fish/deer caught.
+func (c *BaseClient) ForageUpdate(initialDecision shared.ForageDecision, resourceReturn shared.Resources, numberCaught uint) {
+}

--- a/internal/server/forage.go
+++ b/internal/server/forage.go
@@ -165,7 +165,7 @@ func (s *SOMASServer) distributeForageReturn(contributions map[shared.ClientID]s
 		s.clientMap[participantID].ForageUpdate(shared.ForageDecision{
 			Type:         huntReport.ForageType,
 			Contribution: contribution,
-		}, participantReturn)
+		}, participantReturn, huntReport.NumberCaught)
 	}
 }
 

--- a/internal/server/forage_test.go
+++ b/internal/server/forage_test.go
@@ -23,7 +23,7 @@ func (c mockClientForage) DecideForage() (shared.ForageDecision, error) {
 	return c.forageDecision, nil
 }
 
-func (c *mockClientForage) ForageUpdate(forageDecision shared.ForageDecision, resources shared.Resources) {
+func (c *mockClientForage) ForageUpdate(forageDecision shared.ForageDecision, resources shared.Resources, numberCaught uint) {
 	c.forageUpdateCalled = true
 	c.gotForageDecision = forageDecision
 }


### PR DESCRIPTION
# Summary

Following discussion with @NGovani @Eirikalb @QFSW: inform clients about number of deer/fish caught after forage.

## Additional Information

Note: modified T1 and T6 client code but only added the `numberCaught` param to the `ForageUpdate()` definition - no functional changes.

## Test Plan

- all tests still pass.