### PR TITLE
Removing Globals part 3 of 4

### DIFF
--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -51,9 +51,9 @@ func (c *client) StartOfTurn() {
 func (c *client) Initialise(serverReadHandle baseclient.ServerReadHandle) {
 	c.ServerReadHandle = serverReadHandle
 	c.LocalVariableCache = rules.CopyVariableMap(c.ServerReadHandle.GetGameState().RulesInfo.VariableMap)
-	c.ourSpeaker = speaker{c: c, BaseSpeaker: &baseclient.BaseSpeaker{}}
+	c.ourSpeaker = speaker{c: c, BaseSpeaker: &baseclient.BaseSpeaker{GameState: c.ServerReadHandle.GetGameState()}}
 	c.ourJudge = judge{c: c, BaseJudge: &baseclient.BaseJudge{GameState: c.ServerReadHandle.GetGameState()}}
-	c.ourPresident = president{c: c, BasePresident: &baseclient.BasePresident{}}
+	c.ourPresident = president{c: c, BasePresident: &baseclient.BasePresident{GameState: c.ServerReadHandle.GetGameState()}}
 
 	c.initgiftOpinions()
 

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -174,7 +174,7 @@ func (c *client) GetVoteForRule(matrix rules.RuleMatrix) bool {
 
 	newRulesInPlay := make(map[string]rules.RuleMatrix)
 
-	for key, value := range rules.RulesInPlay {
+	for key, value := range c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay {
 		if key == matrix.RuleName {
 			newRulesInPlay[key] = matrix
 		} else {
@@ -182,7 +182,7 @@ func (c *client) GetVoteForRule(matrix rules.RuleMatrix) bool {
 		}
 	}
 
-	if _, ok := rules.RulesInPlay[matrix.RuleName]; ok {
+	if _, ok := c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay[matrix.RuleName]; ok {
 		delete(newRulesInPlay, matrix.RuleName)
 	} else {
 		newRulesInPlay[matrix.RuleName] = c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules[matrix.RuleName]
@@ -205,13 +205,13 @@ func (c *client) GetVoteForRule(matrix rules.RuleMatrix) bool {
 func (c *client) RuleProposal() rules.RuleMatrix {
 	c.locationService.syncGameState(c.ServerReadHandle.GetGameState())
 	c.locationService.syncTrustScore(c.trustScore)
-	internalMap := copyRulesMap(rules.RulesInPlay)
+	internalMap := copyRulesMap(c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay)
 	inputMap := c.locationService.TranslateToInputs(c.LocalVariableCache)
 	c.localInputsCache = inputMap
 	shortestSoFar := -2.0
 	selectedRule := ""
 	for key, rule := range c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules {
-		if _, ok := rules.RulesInPlay[key]; !ok {
+		if _, ok := c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay[key]; !ok {
 			reqInputs := dynamics.SourceRequiredInputs(rule, inputMap)
 			idealLoc, valid := c.locationService.checkIfIdealLocationAvailable(rule, reqInputs)
 			if valid {

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -125,7 +125,7 @@ func (c *client) dynamicAssistedResult(variablesChanged map[rules.VariableFieldN
 	if c.LocalVariableCache != nil {
 		c.LocalVariableCache = c.locationService.UpdateCache(c.LocalVariableCache, variablesChanged)
 		// For testing using available rules
-		return c.locationService.GetRecommendations(variablesChanged, rules.AvailableRules, c.LocalVariableCache)
+		return c.locationService.GetRecommendations(variablesChanged, c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules, c.LocalVariableCache)
 	}
 	return variablesChanged
 }
@@ -185,7 +185,7 @@ func (c *client) GetVoteForRule(matrix rules.RuleMatrix) bool {
 	if _, ok := rules.RulesInPlay[matrix.RuleName]; ok {
 		delete(newRulesInPlay, matrix.RuleName)
 	} else {
-		newRulesInPlay[matrix.RuleName] = rules.AvailableRules[matrix.RuleName]
+		newRulesInPlay[matrix.RuleName] = c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules[matrix.RuleName]
 	}
 
 	// TODO: define postion -> list of variables and values associated with the rule (obtained from IIGO communications)
@@ -210,7 +210,7 @@ func (c *client) RuleProposal() rules.RuleMatrix {
 	c.localInputsCache = inputMap
 	shortestSoFar := -2.0
 	selectedRule := ""
-	for key, rule := range rules.AvailableRules {
+	for key, rule := range c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules {
 		if _, ok := rules.RulesInPlay[key]; !ok {
 			reqInputs := dynamics.SourceRequiredInputs(rule, inputMap)
 			idealLoc, valid := c.locationService.checkIfIdealLocationAvailable(rule, reqInputs)
@@ -218,7 +218,7 @@ func (c *client) RuleProposal() rules.RuleMatrix {
 				ruleDynamics := dynamics.BuildAllDynamics(rule, rule.AuxiliaryVector)
 				distance := dynamics.GetDistanceToSubspace(ruleDynamics, idealLoc)
 				if distance == -1 {
-					return rules.AvailableRules[key]
+					return c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules[key]
 				}
 				if shortestSoFar == -2.0 || shortestSoFar > distance {
 					shortestSoFar = distance
@@ -238,7 +238,7 @@ func (c *client) RuleProposal() rules.RuleMatrix {
 	if selectedRule == "" {
 		selectedRule = "inspect_ballot_rule"
 	}
-	return rules.AvailableRules[selectedRule]
+	return c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules[selectedRule]
 }
 
 // RequestAllocation gives how much island is taking from common pool

--- a/internal/clients/team3/judge.go
+++ b/internal/clients/team3/judge.go
@@ -45,7 +45,7 @@ func (j *judge) InspectHistory(iigoHistory []shared.Accountability, turnsAgo int
 		copyOfGlobalVarCache := rules.CopyVariableMap(j.c.ServerReadHandle.GetGameState().RulesInfo.VariableMap)
 		var rulesAffected []string
 		for _, variable := range variablePairs {
-			valuesToBeAdded, foundRules := rules.PickUpRulesByVariable(variable.VariableName, rules.RulesInPlay, copyOfGlobalVarCache)
+			valuesToBeAdded, foundRules := rules.PickUpRulesByVariable(variable.VariableName, j.c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay, copyOfGlobalVarCache)
 			if foundRules {
 				rulesAffected = append(rulesAffected, valuesToBeAdded...)
 			}
@@ -66,7 +66,7 @@ func (j *judge) InspectHistory(iigoHistory []shared.Accountability, turnsAgo int
 		if j.c.trustScore[clientID] > 80 {
 			tempReturn := outMap[clientID]
 			for _, rule := range rulesAffected {
-				tempReturn.Rules = append(tempReturn.Rules, rules.RulesInPlay[rule])
+				tempReturn.Rules = append(tempReturn.Rules, j.c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay[rule])
 				tempReturn.Evaluations = append(tempReturn.Evaluations, true)
 			}
 			outMap[clientID] = tempReturn
@@ -74,11 +74,11 @@ func (j *judge) InspectHistory(iigoHistory []shared.Accountability, turnsAgo int
 			// All other islands will be evaluated fairly using base implementation.
 			tempReturn := outMap[clientID]
 			for _, rule := range rulesAffected {
-				evaluation := rules.EvaluateRuleFromCaches(rule, rules.RulesInPlay, copyOfGlobalVarCache)
+				evaluation := rules.EvaluateRuleFromCaches(rule, j.c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay, copyOfGlobalVarCache)
 				if evaluation.EvalError != nil {
 					return outMap, false
 				}
-				tempReturn.Rules = append(tempReturn.Rules, rules.RulesInPlay[rule])
+				tempReturn.Rules = append(tempReturn.Rules, j.c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay[rule])
 				tempReturn.Evaluations = append(tempReturn.Evaluations, evaluation.RulePasses)
 			}
 			outMap[clientID] = tempReturn

--- a/internal/clients/team6/iigo.go
+++ b/internal/clients/team6/iigo.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *client) GetClientPresidentPointer() roles.President {
-	return &president{client: c, BasePresident: &baseclient.BasePresident{}}
+	return &president{client: c, BasePresident: &baseclient.BasePresident{GameState: c.ServerReadHandle.GetGameState()}}
 }
 
 func (c *client) GetClientJudgePointer() roles.Judge {
@@ -15,7 +15,7 @@ func (c *client) GetClientJudgePointer() roles.Judge {
 }
 
 func (c *client) GetClientSpeakerPointer() roles.Speaker {
-	return &speaker{client: c, BaseSpeaker: &baseclient.BaseSpeaker{}}
+	return &speaker{client: c, BaseSpeaker: &baseclient.BaseSpeaker{GameState: c.ServerReadHandle.GetGameState()}}
 }
 
 // func (c *client) ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent) {

--- a/internal/common/baseclient/baseSpeaker.go
+++ b/internal/common/baseclient/baseSpeaker.go
@@ -1,16 +1,18 @@
 package baseclient
 
 import (
+	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/rules"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 )
 
 type BaseSpeaker struct {
+	gameState gamestate.ClientGameState
 }
 
 // PayJudge is used for paying judge for his service
 func (s *BaseSpeaker) PayJudge() shared.SpeakerReturnContent {
-	JudgeSalaryRule, ok := rules.RulesInPlay["salary_cycle_judge"]
+	JudgeSalaryRule, ok := s.gameState.RulesInfo.CurrentRulesInPlay["salary_cycle_judge"]
 	var JudgeSalary shared.Resources = 0
 	if ok {
 		JudgeSalary = shared.Resources(JudgeSalaryRule.ApplicableMatrix.At(0, 1))

--- a/internal/common/baseclient/baseSpeaker.go
+++ b/internal/common/baseclient/baseSpeaker.go
@@ -7,12 +7,12 @@ import (
 )
 
 type BaseSpeaker struct {
-	gameState gamestate.ClientGameState
+	GameState gamestate.ClientGameState
 }
 
 // PayJudge is used for paying judge for his service
 func (s *BaseSpeaker) PayJudge() shared.SpeakerReturnContent {
-	JudgeSalaryRule, ok := s.gameState.RulesInfo.CurrentRulesInPlay["salary_cycle_judge"]
+	JudgeSalaryRule, ok := s.GameState.RulesInfo.CurrentRulesInPlay["salary_cycle_judge"]
 	var JudgeSalary shared.Resources = 0
 	if ok {
 		JudgeSalary = shared.Resources(JudgeSalaryRule.ApplicableMatrix.At(0, 1))

--- a/internal/common/baseclient/basejudge.go
+++ b/internal/common/baseclient/basejudge.go
@@ -29,7 +29,7 @@ func (j *BaseJudge) GetSanctionThresholds() map[roles.IIGOSanctionTier]roles.IIG
 // OPTIONAL: override to pay the President less than the full amount.
 func (j *BaseJudge) PayPresident() (shared.Resources, bool) {
 	// TODO Implement opinion based salary payment.
-	PresidentSalaryRule, ok := rules.RulesInPlay["salary_cycle_president"]
+	PresidentSalaryRule, ok := j.GameState.RulesInfo.CurrentRulesInPlay["salary_cycle_president"]
 	var PresidentSalary shared.Resources = 0
 	if ok {
 		PresidentSalary = shared.Resources(PresidentSalaryRule.ApplicableMatrix.At(0, 1))
@@ -47,7 +47,7 @@ func (j *BaseJudge) InspectHistory(iigoHistory []shared.Accountability, turnsAgo
 		clientID := entry.ClientID
 		var rulesAffected []string
 		for _, variable := range variablePairs {
-			valuesToBeAdded, foundRules := rules.PickUpRulesByVariable(variable.VariableName, rules.RulesInPlay, copyOfVarCache)
+			valuesToBeAdded, foundRules := rules.PickUpRulesByVariable(variable.VariableName, j.GameState.RulesInfo.CurrentRulesInPlay, copyOfVarCache)
 			if foundRules {
 				rulesAffected = append(rulesAffected, valuesToBeAdded...)
 			}
@@ -64,11 +64,11 @@ func (j *BaseJudge) InspectHistory(iigoHistory []shared.Accountability, turnsAgo
 		}
 		tempReturn := outputMap[clientID]
 		for _, rule := range rulesAffected {
-			ret := rules.EvaluateRuleFromCaches(rule, rules.RulesInPlay, copyOfVarCache)
+			ret := rules.EvaluateRuleFromCaches(rule, j.GameState.RulesInfo.CurrentRulesInPlay, copyOfVarCache)
 			if ret.EvalError != nil {
 				return outputMap, false
 			}
-			tempReturn.Rules = append(tempReturn.Rules, rules.RulesInPlay[rule])
+			tempReturn.Rules = append(tempReturn.Rules, j.GameState.RulesInfo.CurrentRulesInPlay[rule])
 			tempReturn.Evaluations = append(tempReturn.Evaluations, ret.RulePasses)
 		}
 		outputMap[clientID] = tempReturn

--- a/internal/common/baseclient/basepresident.go
+++ b/internal/common/baseclient/basepresident.go
@@ -9,7 +9,7 @@ import (
 )
 
 type BasePresident struct {
-	gameState gamestate.ClientGameState
+	GameState gamestate.ClientGameState
 }
 
 // EvaluateAllocationRequests sets allowed resource allocation based on each islands requests
@@ -77,7 +77,7 @@ func (p *BasePresident) SetTaxationAmount(islandsResources map[shared.ClientID]s
 
 // PaySpeaker pays the speaker a salary.
 func (p *BasePresident) PaySpeaker() shared.PresidentReturnContent {
-	SpeakerSalaryRule, ok := p.gameState.RulesInfo.CurrentRulesInPlay["salary_cycle_speaker"]
+	SpeakerSalaryRule, ok := p.GameState.RulesInfo.CurrentRulesInPlay["salary_cycle_speaker"]
 	var SpeakerSalary shared.Resources = 0
 	if ok {
 		SpeakerSalary = shared.Resources(SpeakerSalaryRule.ApplicableMatrix.At(0, 1))

--- a/internal/common/baseclient/basepresident.go
+++ b/internal/common/baseclient/basepresident.go
@@ -1,13 +1,16 @@
 package baseclient
 
 import (
+	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"math/rand"
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/rules"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 )
 
-type BasePresident struct{}
+type BasePresident struct {
+	gameState gamestate.ClientGameState
+}
 
 // EvaluateAllocationRequests sets allowed resource allocation based on each islands requests
 func (p *BasePresident) EvaluateAllocationRequests(resourceRequest map[shared.ClientID]shared.Resources, availCommonPool shared.Resources) shared.PresidentReturnContent {
@@ -74,7 +77,7 @@ func (p *BasePresident) SetTaxationAmount(islandsResources map[shared.ClientID]s
 
 // PaySpeaker pays the speaker a salary.
 func (p *BasePresident) PaySpeaker() shared.PresidentReturnContent {
-	SpeakerSalaryRule, ok := rules.RulesInPlay["salary_cycle_speaker"]
+	SpeakerSalaryRule, ok := p.gameState.RulesInfo.CurrentRulesInPlay["salary_cycle_speaker"]
 	var SpeakerSalary shared.Resources = 0
 	if ok {
 		SpeakerSalary = shared.Resources(SpeakerSalaryRule.ApplicableMatrix.At(0, 1))

--- a/internal/common/baseclient/iigo.go
+++ b/internal/common/baseclient/iigo.go
@@ -43,7 +43,7 @@ func (c *BaseClient) RuleProposal() rules.RuleMatrix {
 // GetClientPresidentPointer is called by IIGO to get the client's implementation of the President Role
 // COMPULSORY: ovverride to return a pointer to your own President object
 func (c *BaseClient) GetClientPresidentPointer() roles.President {
-	return &BasePresident{}
+	return &BasePresident{GameState: c.ServerReadHandle.GetGameState()}
 }
 
 // GetClientJudgePointer is called by IIGO to get the client's implementation of the Judge Role
@@ -55,7 +55,7 @@ func (c *BaseClient) GetClientJudgePointer() roles.Judge {
 // GetClientSpeakerPointer is called by IIGO to get the client's implementation of the Speaker Role
 // COMPULSORY: ovverride to return a pointer to your own Speaker object
 func (c *BaseClient) GetClientSpeakerPointer() roles.Speaker {
-	return &BaseSpeaker{}
+	return &BaseSpeaker{GameState: c.ServerReadHandle.GetGameState()}
 }
 
 // GetTaxContribution gives value of how much the island wants to pay in taxes

--- a/internal/common/baseclient/iigo.go
+++ b/internal/common/baseclient/iigo.go
@@ -144,13 +144,13 @@ func (c *BaseClient) RequestAllocation() shared.Resources {
 // with all the rules that are affected by it
 // OPTIONAL
 func (c *BaseClient) CheckCompliance(variable rules.VariableFieldName) bool {
-	rulesAffected, found := rules.PickUpRulesByVariable(variable, rules.RulesInPlay, c.LocalVariableCache)
+	rulesAffected, found := rules.PickUpRulesByVariable(variable, c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay, c.LocalVariableCache)
 	complianceCheck := true
 	if !found {
 		return false
 	}
 	for _, ruleName := range rulesAffected {
-		compliant, err := rules.ComplianceCheck(rules.RulesInPlay[ruleName], c.LocalVariableCache)
+		compliant, err := rules.ComplianceCheck(c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay[ruleName], c.LocalVariableCache, c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay)
 		if err != nil {
 			c.Logf("Attempted to evaluate rule, failed with error %v", err)
 			return false
@@ -164,12 +164,12 @@ func (c *BaseClient) CheckCompliance(variable rules.VariableFieldName) bool {
 // a given variable must be to ensure compliance. Recomendations are only made for unlinked rules!
 // OPTIONAL
 func (c *BaseClient) GetRecommendation(variable rules.VariableFieldName) (compliantValue rules.VariableValuePair, success bool) {
-	rulesAffected, found := rules.PickUpRulesByVariable(variable, rules.RulesInPlay, c.LocalVariableCache)
+	rulesAffected, found := rules.PickUpRulesByVariable(variable, c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay, c.LocalVariableCache)
 	if !found {
 		return c.LocalVariableCache[variable], false
 	}
 	for _, ruleName := range rulesAffected {
-		ruleToConsider := rules.RulesInPlay[ruleName]
+		ruleToConsider := c.ServerReadHandle.GetGameState().RulesInfo.CurrentRulesInPlay[ruleName]
 		if !ruleToConsider.Link.Linked {
 			newMap, ok := rules.ComplianceRecommendation(ruleToConsider, c.LocalVariableCache)
 			if ok {

--- a/internal/common/baseclient/iigo.go
+++ b/internal/common/baseclient/iigo.go
@@ -33,7 +33,7 @@ func (c *BaseClient) ResourceReport() shared.ResourcesReport {
 // is then for modifying the rule's content only, it won't put the rule in/out of
 // play. Only a mutable rule's content can be modified.
 func (c *BaseClient) RuleProposal() rules.RuleMatrix {
-	allRules := rules.AvailableRules
+	allRules := c.ServerReadHandle.GetGameState().RulesInfo.AvailableRules
 	for _, ruleMatrix := range allRules {
 		return ruleMatrix
 	}

--- a/internal/common/gamestate/gamestate.go
+++ b/internal/common/gamestate/gamestate.go
@@ -6,7 +6,6 @@ import (
 	"github.com/SOMAS2020/SOMAS2020/internal/common/foraging"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/rules"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
-	"gonum.org/v1/gonum/mat"
 )
 
 // GameState represents the game's state.
@@ -147,17 +146,9 @@ func copyIIGOHistory(iigoHistory map[uint][]shared.Accountability) map[uint][]sh
 func copyRulesContext(oldContext RulesContext) RulesContext {
 	return RulesContext{
 		VariableMap:        copyVariableMap(oldContext.VariableMap),
-		CurrentRulesInPlay: copyRulesMap(oldContext.CurrentRulesInPlay),
-		AvailableRules:     copyRulesMap(oldContext.AvailableRules),
+		CurrentRulesInPlay: rules.CopyRulesMap(oldContext.CurrentRulesInPlay),
+		AvailableRules:     rules.CopyRulesMap(oldContext.AvailableRules),
 	}
-}
-
-func copyRulesMap(rulesMap map[string]rules.RuleMatrix) map[string]rules.RuleMatrix {
-	targetMap := make(map[string]rules.RuleMatrix)
-	for key, value := range rulesMap {
-		targetMap[key] = copySingleRuleMatrix(value)
-	}
-	return targetMap
 }
 
 func copyVariableMap(varMap map[rules.VariableFieldName]rules.VariableValuePair) map[rules.VariableFieldName]rules.VariableValuePair {
@@ -169,31 +160,6 @@ func copyVariableMap(varMap map[rules.VariableFieldName]rules.VariableValuePair)
 		}
 	}
 	return targetMap
-}
-
-func copySingleRuleMatrix(inp rules.RuleMatrix) rules.RuleMatrix {
-	return rules.RuleMatrix{
-		RuleName:          inp.RuleName,
-		RequiredVariables: copyRequiredVariables(inp.RequiredVariables),
-		ApplicableMatrix:  *mat.DenseCopyOf(&inp.ApplicableMatrix),
-		AuxiliaryVector:   *mat.VecDenseCopyOf(&inp.AuxiliaryVector),
-		Mutable:           inp.Mutable,
-		Link:              copyLink(inp.Link),
-	}
-}
-
-func copyLink(inp rules.RuleLink) rules.RuleLink {
-	return rules.RuleLink{
-		Linked:     inp.Linked,
-		LinkType:   inp.LinkType,
-		LinkedRule: inp.LinkedRule,
-	}
-}
-
-func copyRequiredVariables(inp []rules.VariableFieldName) []rules.VariableFieldName {
-	targetList := make([]rules.VariableFieldName, len(inp))
-	copy(targetList, inp)
-	return targetList
 }
 
 func copySingleIIGOEntry(input []shared.Accountability) []shared.Accountability {

--- a/internal/common/rules/basicruleevaluator_test.go
+++ b/internal/common/rules/basicruleevaluator_test.go
@@ -8,7 +8,8 @@ import (
 
 // TestBasicRuleEvaluatorPositive Checks whether rule we expect to evaluate as true actually evaluates as such
 func TestBasicRuleEvaluatorPositive(t *testing.T) {
-	ret := EvaluateRuleFromCaches("Kinda Complicated Rule", AvailableRules, generateMockVarCache())
+	avail, _ := InitialRuleRegistration(false)
+	ret := EvaluateRuleFromCaches("Kinda Complicated Rule", avail, generateMockVarCache())
 	if !ret.RulePasses {
 		t.Errorf("Rule evaluation came as false, when it was expected to be true, potential error with value '%v'", ret.EvalError)
 	}
@@ -16,24 +17,27 @@ func TestBasicRuleEvaluatorPositive(t *testing.T) {
 
 // TestBasicRuleEvaluatorNegative Checks whether rule we expect to evaluate as false actually evaluates as such
 func TestBasicRuleEvaluatorNegative(t *testing.T) {
-	registerTestRule(AvailableRules)
-	ret := EvaluateRuleFromCaches("Kinda Test Rule", AvailableRules, generateMockVarCache())
+	avail, _ := InitialRuleRegistration(false)
+	registerTestRule(avail)
+	ret := EvaluateRuleFromCaches("Kinda Test Rule", avail, generateMockVarCache())
 	if ret.RulePasses || ret.EvalError != nil {
 		t.Errorf("Rule evaluation came as true, when it was expected to be false, potential error with value '%v'", ret.EvalError)
 	}
 }
 
 func TestBasicRealValuedRuleEvaluator(t *testing.T) {
-	registerNewRealValuedRule(t)
-	ret := EvaluateRuleFromCaches("Real Test rule", AvailableRules, generateMockVarCache())
+	avail, _ := InitialRuleRegistration(false)
+	registerNewRealValuedRule(t, avail)
+	ret := EvaluateRuleFromCaches("Real Test rule", avail, generateMockVarCache())
 	if !ret.RulePasses && ret.RealOutputVal != 2.0 {
 		t.Errorf("Real values rule evaluation error, expected true got '%v', value expected '2' got '%v'", ret.RulePasses, ret.RealOutputVal)
 	}
 }
 
 func TestBasicLinkedRuleEvaluator(t *testing.T) {
-	registerNewLinkedRule(t)
-	ret := EvaluateRuleFromCaches("Linked test rule", AvailableRules, generateMockVarCache())
+	avail, _ := InitialRuleRegistration(false)
+	registerNewLinkedRule(t, avail)
+	ret := EvaluateRuleFromCaches("Linked test rule", avail, generateMockVarCache())
 	if ret.EvalError != nil {
 		t.Errorf("Linked rule evaluation error: %v", ret.EvalError)
 	}
@@ -63,7 +67,7 @@ func generateMockVarCache() map[VariableFieldName]VariableValuePair {
 	}
 }
 
-func registerNewRealValuedRule(t *testing.T) {
+func registerNewRealValuedRule(t *testing.T, rulesCache map[string]RuleMatrix) {
 	//A very contrived rule//
 	name := "Real Test rule"
 	reqVar := []VariableFieldName{
@@ -78,7 +82,7 @@ func registerNewRealValuedRule(t *testing.T) {
 	aux := []float64{1, 1, 4, 0}
 	AuxiliaryVector := mat.NewVecDense(4, aux)
 
-	_, ruleError := RegisterNewRule(name, reqVar, *CoreMatrix, *AuxiliaryVector, false, RuleLink{
+	_, ruleError := RegisterNewRuleInternal(name, reqVar, *CoreMatrix, *AuxiliaryVector, rulesCache, false, RuleLink{
 		Linked: false,
 	})
 	if ruleError != nil {
@@ -87,7 +91,7 @@ func registerNewRealValuedRule(t *testing.T) {
 	// Check internal/clients/team3/client.go for an implementation of a basic evaluator for this rule
 }
 
-func registerNewLinkedRule(t *testing.T) {
+func registerNewLinkedRule(t *testing.T, rulesCache map[string]RuleMatrix) {
 	name := "Linked test rule"
 	reqVar := []VariableFieldName{
 		NumberOfIslandsContributingToCommonPool,
@@ -101,7 +105,7 @@ func registerNewLinkedRule(t *testing.T) {
 	aux := []float64{1, 1, 3, 0}
 	AuxiliaryVector := mat.NewVecDense(4, aux)
 
-	_, ruleError := RegisterNewRule(name, reqVar, *CoreMatrix, *AuxiliaryVector, false, RuleLink{
+	_, ruleError := RegisterNewRuleInternal(name, reqVar, *CoreMatrix, *AuxiliaryVector, rulesCache, false, RuleLink{
 		Linked:     true,
 		LinkType:   ParentFailAutoRulePass,
 		LinkedRule: "Kinda Complicated Rule",

--- a/internal/common/rules/clienttools.go
+++ b/internal/common/rules/clienttools.go
@@ -7,12 +7,12 @@ import (
 
 // ComplianceCheck Gives a simple check for compliance to clients, they just need to feed in a RuleMatrix and the
 // variable cache they want to feed from
-func ComplianceCheck(rule RuleMatrix, variables map[VariableFieldName]VariableValuePair) (compliant bool, ruleError error) {
+func ComplianceCheck(rule RuleMatrix, variables map[VariableFieldName]VariableValuePair, inPlayRules map[string]RuleMatrix) (compliant bool, ruleError error) {
 	if checkAllVariablesAvailable(rule.RequiredVariables, variables) {
 		ruleCache := map[string]RuleMatrix{}
 		ruleCache[rule.RuleName] = rule
 		if rule.Link.Linked {
-			ruleCache[rule.Link.LinkedRule] = RulesInPlay[rule.Link.LinkedRule]
+			ruleCache[rule.Link.LinkedRule] = inPlayRules[rule.Link.LinkedRule]
 		}
 		evalResult := EvaluateRuleFromCaches(rule.RuleName, ruleCache, variables)
 		return evalResult.RulePasses, evalResult.EvalError

--- a/internal/common/rules/clienttools_test.go
+++ b/internal/common/rules/clienttools_test.go
@@ -495,7 +495,8 @@ func TestComplianceCheck(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := ComplianceCheck(tc.rule, tc.variables)
+			_, inPlay := InitialRuleRegistration(true)
+			res, err := ComplianceCheck(tc.rule, tc.variables, inPlay)
 			testutils.CompareTestErrors(tc.err, err, t)
 			if res != tc.success {
 				t.Errorf("Expected %v got %v", tc.success, res)

--- a/internal/common/rules/globalruleregistration.go
+++ b/internal/common/rules/globalruleregistration.go
@@ -7,13 +7,19 @@ import (
 )
 
 // Init Registers all global scoped rules
-func init() {
-	registerDemoRule()
-	registerRulesByMass()
+func InitialRuleRegistration(startWithRules bool) (AvailableRules map[string]RuleMatrix, RulesInPlay map[string]RuleMatrix) {
+	availableRules := make(map[string]RuleMatrix)
+	rulesInPlay := make(map[string]RuleMatrix)
+	availableRules = registerDemoRule(availableRules)
+	availableRules = registerRulesByMass(availableRules)
+	if startWithRules {
+		rulesInPlay = CopyRulesMap(availableRules)
+	}
+	return availableRules, rulesInPlay
 }
 
 // registerDemoRule Defines and registers demo rule
-func registerDemoRule() {
+func registerDemoRule(AvailableRules map[string]RuleMatrix) map[string]RuleMatrix {
 
 	//A very contrived rule//
 	name := "Kinda Complicated Rule"
@@ -29,13 +35,14 @@ func registerDemoRule() {
 	aux := []float64{1, 1, 2, 0}
 	AuxiliaryVector := mat.NewVecDense(4, aux)
 
-	_, ruleErr := RegisterNewRule(name, reqVar, *CoreMatrix, *AuxiliaryVector, false, RuleLink{
+	_, ruleErr := RegisterNewRuleInternal(name, reqVar, *CoreMatrix, *AuxiliaryVector, AvailableRules, false, RuleLink{
 		Linked: false,
 	})
 	if ruleErr != nil {
 		panic(ruleErr.Error())
 	}
 	// Check internal/clients/team3/client.go for an implementation of a basic evaluator for this rule
+	return AvailableRules
 }
 
 // RawRuleSpecification allows a user to use the CompileRuleCase function to build a rule matrix
@@ -50,7 +57,7 @@ type RawRuleSpecification struct {
 	LinkedRule string
 }
 
-func registerRulesByMass() {
+func registerRulesByMass(availableRules map[string]RuleMatrix) map[string]RuleMatrix {
 	ruleSpecs := []RawRuleSpecification{
 		{
 			Name: "inspect_ballot_rule",
@@ -494,11 +501,12 @@ func registerRulesByMass() {
 				LinkedRule: rs.LinkedRule,
 			}
 		}
-		_, ruleError := RegisterNewRule(rs.Name, rs.ReqVar, *CoreMatrix, *AuxiliaryVector, rs.Mutable, ruleLink)
+		_, ruleError := RegisterNewRuleInternal(rs.Name, rs.ReqVar, *CoreMatrix, *AuxiliaryVector, availableRules, rs.Mutable, ruleLink)
 		if ruleError != nil {
 			panic(ruleError.Error())
 		}
 	}
+	return availableRules
 }
 
 // CompileRuleCase allows an agent to quickly build a RuleMatrix using the RawRuleSpecification

--- a/internal/common/rules/globalruleregistration.go
+++ b/internal/common/rules/globalruleregistration.go
@@ -457,9 +457,8 @@ func registerRulesByMass(availableRules map[string]RuleMatrix) map[string]RuleMa
 			Name: "tax_decision",
 			ReqVar: []VariableFieldName{
 				TaxDecisionMade,
-				IslandTaxContribution,
 			},
-			Values:     []float64{1, 0, -1},
+			Values:     []float64{1, -1},
 			Aux:        []float64{0},
 			Mutable:    false,
 			Linked:     true,
@@ -470,9 +469,8 @@ func registerRulesByMass(availableRules map[string]RuleMatrix) map[string]RuleMa
 			Name: "allocation_decision",
 			ReqVar: []VariableFieldName{
 				AllocationMade,
-				IslandAllocation,
 			},
-			Values:     []float64{1, 0, -1},
+			Values:     []float64{1, -1},
 			Aux:        []float64{0},
 			Mutable:    false,
 			Linked:     true,

--- a/internal/common/rules/globalruleregistration_test.go
+++ b/internal/common/rules/globalruleregistration_test.go
@@ -8,8 +8,10 @@ func TestGlobalRuleRegistration(t *testing.T) {
 		"Kinda Complicated Rule",
 	}
 
+	avail, _ := InitialRuleRegistration(false)
+
 	for _, v := range rulesToFind {
-		if _, ok := AvailableRules[v]; !ok {
+		if _, ok := avail[v]; !ok {
 			t.Errorf("Required rule '%v' not found", v)
 		}
 	}

--- a/internal/common/rules/globalrules_test.go
+++ b/internal/common/rules/globalrules_test.go
@@ -34,7 +34,8 @@ func TestIIGOMonitorRulePermission1(t *testing.T) {
 	for _, tc := range cases {
 		UpdateVariableInternal(MonitorRoleDecideToMonitor, MakeVariableValuePair(MonitorRoleDecideToMonitor, []float64{tc.decideToMonitor}), dummyCache)
 		UpdateVariableInternal(MonitorRoleAnnounce, MakeVariableValuePair(MonitorRoleAnnounce, []float64{tc.announce}), dummyCache)
-		eval := EvaluateRuleFromCaches("iigo_monitor_rule_permission_1", AvailableRules, dummyCache)
+		avail, _ := InitialRuleRegistration(false)
+		eval := EvaluateRuleFromCaches("iigo_monitor_rule_permission_1", avail, dummyCache)
 
 		if eval.RulePasses != tc.expected {
 			t.Errorf("MonitorRulePermission1 - Failed. Input (%v,%v). Rule evaluated to %v, but expected %v.",
@@ -75,7 +76,8 @@ func TestIIGOMonitorRulePermission2(t *testing.T) {
 	for _, tc := range cases {
 		UpdateVariableInternal(MonitorRoleEvalResult, MakeVariableValuePair(MonitorRoleEvalResult, []float64{tc.evalResult}), dummyCache)
 		UpdateVariableInternal(MonitorRoleEvalResultDecide, MakeVariableValuePair(MonitorRoleEvalResultDecide, []float64{tc.evalResultDecide}), dummyCache)
-		eval := EvaluateRuleFromCaches("iigo_monitor_rule_permission_2", AvailableRules, dummyCache)
+		avail, _ := InitialRuleRegistration(false)
+		eval := EvaluateRuleFromCaches("iigo_monitor_rule_permission_2", avail, dummyCache)
 
 		if eval.RulePasses != tc.expected {
 			t.Errorf("MonitorRulePermission2 - Failed. Input (%v,%v). Rule evaluated to %v, but expected %v.",

--- a/internal/common/rules/globalrulescache.go
+++ b/internal/common/rules/globalrulescache.go
@@ -54,11 +54,6 @@ func PullRuleOutOfPlayInternal(rulename string, allRules map[string]RuleMatrix, 
 	return &RuleError{Err: errors.Errorf("Rule '%v' does not exist in available rules cache", rulename), ErrorType: RuleNotInAvailableRulesCache}
 }
 
-// ModifyRule allows for rules that are flagged as mutable to be modified
-func ModifyRule(rulename string, newMatrix mat.Dense, newAuxiliary mat.VecDense) error {
-	return ModifyRuleInternal(rulename, newMatrix, newAuxiliary, AvailableRules, RulesInPlay)
-}
-
 func ModifyRuleInternal(rulename string, newMatrix mat.Dense, newAuxiliary mat.VecDense, rulesCache map[string]RuleMatrix, inPlayCache map[string]RuleMatrix) error {
 	if _, ok := rulesCache[rulename]; ok {
 		oldRuleMatrix := rulesCache[rulename]

--- a/internal/common/rules/globalrulescache.go
+++ b/internal/common/rules/globalrulescache.go
@@ -5,12 +5,6 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
-// AvailableRules is a global cache of all rules that are available to agents
-var AvailableRules = map[string]RuleMatrix{}
-
-// RulesInPlay is a global cache of all rules currently in effect
-var RulesInPlay = map[string]RuleMatrix{}
-
 // RegisterNewRuleInternal provides primal register logic for any rule cache
 func RegisterNewRuleInternal(ruleName string, requiredVariables []VariableFieldName, applicableMatrix mat.Dense, auxiliaryVector mat.VecDense, ruleStore map[string]RuleMatrix, mutable bool, link RuleLink) (constructedMatrix *RuleMatrix, Error error) {
 	if _, ok := ruleStore[ruleName]; ok {

--- a/internal/common/rules/globalrulescache.go
+++ b/internal/common/rules/globalrulescache.go
@@ -38,11 +38,6 @@ func PullRuleIntoPlayInternal(rulename string, allRules map[string]RuleMatrix, p
 	return &RuleError{Err: errors.Errorf("Rule '%v' does not exist in available rules", rulename), ErrorType: RuleNotInAvailableRulesCache}
 }
 
-// PullRuleOutOfPlay provides disengagement logic for global rules in play cache
-func PullRuleOutOfPlay(rulename string) error {
-	return PullRuleOutOfPlayInternal(rulename, AvailableRules, RulesInPlay)
-}
-
 // PullRuleOutOfPlayInternal provides primal rule disengagement logic for any pair of caches
 func PullRuleOutOfPlayInternal(rulename string, allRules map[string]RuleMatrix, playRules map[string]RuleMatrix) error {
 	if _, ok := allRules[rulename]; ok {

--- a/internal/common/rules/globalrulescache.go
+++ b/internal/common/rules/globalrulescache.go
@@ -11,11 +11,6 @@ var AvailableRules = map[string]RuleMatrix{}
 // RulesInPlay is a global cache of all rules currently in effect
 var RulesInPlay = map[string]RuleMatrix{}
 
-// RegisterNewRule Creates and registers new rule based on inputs
-func RegisterNewRule(ruleName string, requiredVariables []VariableFieldName, applicableMatrix mat.Dense, auxiliaryVector mat.VecDense, mutable bool, link RuleLink) (constructedMatrix *RuleMatrix, Error error) {
-	return RegisterNewRuleInternal(ruleName, requiredVariables, applicableMatrix, auxiliaryVector, AvailableRules, mutable, link)
-}
-
 // RegisterNewRuleInternal provides primal register logic for any rule cache
 func RegisterNewRuleInternal(ruleName string, requiredVariables []VariableFieldName, applicableMatrix mat.Dense, auxiliaryVector mat.VecDense, ruleStore map[string]RuleMatrix, mutable bool, link RuleLink) (constructedMatrix *RuleMatrix, Error error) {
 	if _, ok := ruleStore[ruleName]; ok {
@@ -120,4 +115,37 @@ func checkLinking(ruleName string, availableRules map[string]RuleMatrix) (string
 		}
 	}
 	return "", false
+}
+
+func CopyRulesMap(rulesMap map[string]RuleMatrix) map[string]RuleMatrix {
+	targetMap := make(map[string]RuleMatrix)
+	for key, value := range rulesMap {
+		targetMap[key] = copySingleRuleMatrix(value)
+	}
+	return targetMap
+}
+
+func copySingleRuleMatrix(inp RuleMatrix) RuleMatrix {
+	return RuleMatrix{
+		RuleName:          inp.RuleName,
+		RequiredVariables: copyRequiredVariables(inp.RequiredVariables),
+		ApplicableMatrix:  *mat.DenseCopyOf(&inp.ApplicableMatrix),
+		AuxiliaryVector:   *mat.VecDenseCopyOf(&inp.AuxiliaryVector),
+		Mutable:           inp.Mutable,
+		Link:              copyLink(inp.Link),
+	}
+}
+
+func copyLink(inp RuleLink) RuleLink {
+	return RuleLink{
+		Linked:     inp.Linked,
+		LinkType:   inp.LinkType,
+		LinkedRule: inp.LinkedRule,
+	}
+}
+
+func copyRequiredVariables(inp []VariableFieldName) []VariableFieldName {
+	targetList := make([]VariableFieldName, len(inp))
+	copy(targetList, inp)
+	return targetList
 }

--- a/internal/common/rules/globalrulescache.go
+++ b/internal/common/rules/globalrulescache.go
@@ -22,11 +22,6 @@ func RegisterNewRuleInternal(ruleName string, requiredVariables []VariableFieldN
 	return &rm, nil
 }
 
-// PullRuleIntoPlay provides engagement logic for global rules in play cache
-func PullRuleIntoPlay(rulename string) error {
-	return PullRuleIntoPlayInternal(rulename, AvailableRules, RulesInPlay)
-}
-
 // PullRuleIntoPlayInternal provides primal rule engagement logic for any pair of caches
 func PullRuleIntoPlayInternal(rulename string, allRules map[string]RuleMatrix, playRules map[string]RuleMatrix) error {
 	if _, ok := allRules[rulename]; ok {

--- a/internal/server/iigo.go
+++ b/internal/server/iigo.go
@@ -28,7 +28,6 @@ func (s *SOMASServer) updateIIGOHistoryAndRules(clientID shared.ClientID, pairs 
 			Pairs:    pairs,
 		},
 	)
-	s.gameState.RulesInfo.CurrentRulesInPlay = rules.RulesInPlay
 }
 
 func (s *SOMASServer) runIIGOTax() error {

--- a/internal/server/iigointernal/executive.go
+++ b/internal/server/iigointernal/executive.go
@@ -248,7 +248,7 @@ func (e *executive) requestRuleProposal() error { //TODO: add checks for if immu
 	var ruleProposals []rules.RuleMatrix
 	for _, island := range e.getIslandAlive() {
 		proposedRuleMatrix := e.iigoClients[shared.ClientID(int(island))].RuleProposal()
-		if checkRuleIsValid(proposedRuleMatrix.RuleName, rules.AvailableRules) {
+		if checkRuleIsValid(proposedRuleMatrix.RuleName, e.gameState.RulesInfo.AvailableRules) {
 			ruleProposals = append(ruleProposals, proposedRuleMatrix)
 		}
 	}

--- a/internal/server/iigointernal/executive_test.go
+++ b/internal/server/iigointernal/executive_test.go
@@ -690,8 +690,10 @@ func TestReplyAllocationRequest(t *testing.T) {
 		},
 	}
 
-	rules.PullRuleIntoPlay("allocation_decision")
-	rules.PullRuleIntoPlay("check_allocation_rule")
+	rulesInPlay := map[string]rules.RuleMatrix{}
+
+	rules.PullRuleIntoPlayInternal("allocation_decision", generateRuleStore(), rulesInPlay)
+	rules.PullRuleIntoPlayInternal("check_allocation_rule", generateRuleStore(), rulesInPlay)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -894,8 +896,10 @@ func TestBroadcastTaxation(t *testing.T) {
 		},
 	}
 
-	rules.PullRuleIntoPlay("tax_decision")
-	rules.PullRuleIntoPlay("check_taxation_rule")
+	rulesInPlay := map[string]rules.RuleMatrix{}
+
+	rules.PullRuleIntoPlayInternal("tax_decision", generateRuleStore(), rulesInPlay)
+	rules.PullRuleIntoPlayInternal("check_taxation_rule", generateRuleStore(), rulesInPlay)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/iigointernal/executive_test.go
+++ b/internal/server/iigointernal/executive_test.go
@@ -692,8 +692,14 @@ func TestReplyAllocationRequest(t *testing.T) {
 
 	rulesInPlay := map[string]rules.RuleMatrix{}
 
-	rules.PullRuleIntoPlayInternal("allocation_decision", generateRuleStore(), rulesInPlay)
-	rules.PullRuleIntoPlayInternal("check_allocation_rule", generateRuleStore(), rulesInPlay)
+	err := rules.PullRuleIntoPlayInternal("allocation_decision", generateRuleStore(), rulesInPlay)
+	if err != nil {
+		t.Errorf("Unexpected Error when pulling rule into play: %v", err)
+	}
+	err = rules.PullRuleIntoPlayInternal("check_allocation_rule", generateRuleStore(), rulesInPlay)
+	if err != nil {
+		t.Errorf("Unexpected Error when pulling rule into play: %v", err)
+	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -910,8 +916,14 @@ func TestBroadcastTaxation(t *testing.T) {
 		},
 	}
 
-	rules.PullRuleIntoPlayInternal("tax_decision", generateRuleStore(), rulesInPlay)
-	rules.PullRuleIntoPlayInternal("check_taxation_rule", generateRuleStore(), rulesInPlay)
+	err := rules.PullRuleIntoPlayInternal("tax_decision", generateRuleStore(), rulesInPlay)
+	if err != nil {
+		t.Errorf("Unexpected Error when pulling rule into play: %v", err)
+	}
+	err = rules.PullRuleIntoPlayInternal("check_taxation_rule", generateRuleStore(), rulesInPlay)
+	if err != nil {
+		t.Errorf("Unexpected Error when pulling rule into play: %v", err)
+	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/iigointernal/executive_test.go
+++ b/internal/server/iigointernal/executive_test.go
@@ -712,6 +712,9 @@ func TestReplyAllocationRequest(t *testing.T) {
 			}
 			fakeServer := fakeServerHandle{
 				PresidentID: tc.bPresident.PresidentID,
+				RuleInfo: gamestate.RulesContext{
+					CurrentRulesInPlay: rulesInPlay,
+				},
 			}
 
 			aliveID := []shared.ClientID{}
@@ -853,6 +856,7 @@ func expectedTax(r shared.ResourcesReport) shared.Resources {
 }
 
 func TestBroadcastTaxation(t *testing.T) {
+	rulesInPlay := map[string]rules.RuleMatrix{}
 	var logging shared.Logger = func(format string, a ...interface{}) {}
 	cases := []struct {
 		name          string
@@ -866,6 +870,11 @@ func TestBroadcastTaxation(t *testing.T) {
 				PresidentID:     shared.Team4,
 				clientPresident: &baseclient.BasePresident{},
 				logger:          logging,
+				gameState: &gamestate.GameState{
+					RulesInfo: gamestate.RulesContext{
+						CurrentRulesInPlay: rulesInPlay,
+					},
+				},
 			},
 			clientReports: map[shared.ClientID]shared.ResourcesReport{
 				shared.Team1: {ReportedAmount: 30, Reported: true},
@@ -883,6 +892,11 @@ func TestBroadcastTaxation(t *testing.T) {
 				PresidentID:     shared.Team1,
 				clientPresident: &baseclient.BasePresident{},
 				logger:          logging,
+				gameState: &gamestate.GameState{
+					RulesInfo: gamestate.RulesContext{
+						CurrentRulesInPlay: rulesInPlay,
+					},
+				},
 			},
 			clientReports: map[shared.ClientID]shared.ResourcesReport{
 				shared.Team1: {ReportedAmount: 30, Reported: true},
@@ -895,8 +909,6 @@ func TestBroadcastTaxation(t *testing.T) {
 			commonPool: 150,
 		},
 	}
-
-	rulesInPlay := map[string]rules.RuleMatrix{}
 
 	rules.PullRuleIntoPlayInternal("tax_decision", generateRuleStore(), rulesInPlay)
 	rules.PullRuleIntoPlayInternal("check_taxation_rule", generateRuleStore(), rulesInPlay)
@@ -919,6 +931,9 @@ func TestBroadcastTaxation(t *testing.T) {
 			}
 			fakeServer := fakeServerHandle{
 				PresidentID: tc.bPresident.PresidentID,
+				RuleInfo: gamestate.RulesContext{
+					CurrentRulesInPlay: rulesInPlay,
+				},
 			}
 
 			aliveID := []shared.ClientID{}
@@ -977,6 +992,7 @@ type fakeServerHandle struct {
 	PresidentID shared.ClientID
 	JudgeID     shared.ClientID
 	SpeakerID   shared.ClientID
+	RuleInfo    gamestate.RulesContext
 }
 
 func (s fakeServerHandle) GetGameState() gamestate.ClientGameState {
@@ -984,6 +1000,7 @@ func (s fakeServerHandle) GetGameState() gamestate.ClientGameState {
 		SpeakerID:   s.SpeakerID,
 		JudgeID:     s.JudgeID,
 		PresidentID: s.PresidentID,
+		RulesInfo:   s.RuleInfo,
 	}
 }
 

--- a/internal/server/iigointernal/judiciary.go
+++ b/internal/server/iigointernal/judiciary.go
@@ -114,10 +114,12 @@ func (j *judiciary) inspectHistory(iigoHistory []shared.Accountability) (map[sha
 		}
 	}
 
+	rulesInPlay := j.gameState.RulesInfo.CurrentRulesInPlay
+
 	//Quit early if CP does not have enough resources for historical Retribution
 	if success && !CheckEnoughInCommonPool(j.gameConf.HistoricalRetributionActionCost, j.gameState) {
 		finalResults = mergeEvaluationReturn(tempResults, finalResults)
-		entryForHistoryCache := cullCheckedRules(iigoHistory, finalResults, rules.RulesInPlay, j.gameState.RulesInfo.VariableMap)
+		entryForHistoryCache := cullCheckedRules(iigoHistory, finalResults, rulesInPlay, j.gameState.RulesInfo.VariableMap)
 		j.cycleHistoryCache(entryForHistoryCache, int(j.gameConf.HistoryCacheDepth))
 		j.evaluationResults = finalResults
 		return j.evaluationResults, success
@@ -130,7 +132,7 @@ func (j *judiciary) inspectHistory(iigoHistory []shared.Accountability) (map[sha
 			//Quit if taking resources goes wrong
 			if success {
 				finalResults = mergeEvaluationReturn(tempResults, finalResults)
-				entryForHistoryCache := cullCheckedRules(iigoHistory, finalResults, rules.RulesInPlay, j.gameState.RulesInfo.VariableMap)
+				entryForHistoryCache := cullCheckedRules(iigoHistory, finalResults, rulesInPlay, j.gameState.RulesInfo.VariableMap)
 				j.cycleHistoryCache(entryForHistoryCache, int(j.gameConf.HistoryCacheDepth))
 				j.evaluationResults = finalResults
 				return j.evaluationResults, success
@@ -157,7 +159,7 @@ func (j *judiciary) inspectHistory(iigoHistory []shared.Accountability) (map[sha
 	j.monitoring.addToCache(j.JudgeID, variablesToCache, valuesToCache)
 
 	finalResults = mergeEvaluationReturn(tempResults, finalResults)
-	entryForHistoryCache := cullCheckedRules(iigoHistory, finalResults, rules.RulesInPlay, j.gameState.RulesInfo.VariableMap)
+	entryForHistoryCache := cullCheckedRules(iigoHistory, finalResults, rulesInPlay, j.gameState.RulesInfo.VariableMap)
 	j.cycleHistoryCache(entryForHistoryCache, int(j.gameConf.HistoryCacheDepth))
 	j.evaluationResults = finalResults
 	return j.evaluationResults, success
@@ -276,7 +278,7 @@ func (j *judiciary) sanctionEvaluate(reportedIslandResources map[shared.ClientID
 		broadcastPardonCommunications(j.iigoClients, j.JudgeID, communications, *j.gameState)
 	}
 	j.localSanctionCache = newSanctionMap
-	totalSanctionPerAgent := runEvaluationRulesOnSanctions(j.localSanctionCache, reportedIslandResources, rules.RulesInPlay, j.gameConf.AssumedResourcesNoReport)
+	totalSanctionPerAgent := runEvaluationRulesOnSanctions(j.localSanctionCache, reportedIslandResources, j.gameState.RulesInfo.CurrentRulesInPlay, j.gameConf.AssumedResourcesNoReport)
 	j.gameState.IIGOSanctionMap = totalSanctionPerAgent
 	for clientID, sanctionedResources := range totalSanctionPerAgent {
 		communicateWithIslands(j.iigoClients, j.JudgeID, clientID, map[shared.CommunicationFieldName]shared.CommunicationContent{

--- a/internal/server/iigointernal/judiciary_test.go
+++ b/internal/server/iigointernal/judiciary_test.go
@@ -1842,9 +1842,8 @@ func generateDummyRuleMatrices() []rules.RuleMatrix {
 			name: "tax_decision",
 			reqVar: []rules.VariableFieldName{
 				rules.TaxDecisionMade,
-				rules.IslandTaxContribution,
 			},
-			v:       []float64{1, 0, -1},
+			v:       []float64{1, -1},
 			aux:     []float64{0},
 			mutable: false,
 		},
@@ -1852,9 +1851,8 @@ func generateDummyRuleMatrices() []rules.RuleMatrix {
 			name: "allocation_decision",
 			reqVar: []rules.VariableFieldName{
 				rules.AllocationMade,
-				rules.IslandAllocation,
 			},
-			v:       []float64{1, 0, -1},
+			v:       []float64{1, -1},
 			aux:     []float64{0},
 			mutable: false,
 		},

--- a/internal/server/iigointernal/judiciary_test.go
+++ b/internal/server/iigointernal/judiciary_test.go
@@ -1838,6 +1838,26 @@ func generateDummyRuleMatrices() []rules.RuleMatrix {
 			aux:     []float64{0},
 			mutable: true,
 		},
+		{
+			name: "tax_decision",
+			reqVar: []rules.VariableFieldName{
+				rules.TaxDecisionMade,
+				rules.IslandTaxContribution,
+			},
+			v:       []float64{1, 0, -1},
+			aux:     []float64{0},
+			mutable: false,
+		},
+		{
+			name: "allocation_decision",
+			reqVar: []rules.VariableFieldName{
+				rules.AllocationMade,
+				rules.IslandAllocation,
+			},
+			v:       []float64{1, 0, -1},
+			aux:     []float64{0},
+			mutable: false,
+		},
 	}
 	var outputArray []rules.RuleMatrix
 	for _, rs := range ruleSpecs {

--- a/internal/server/iigointernal/legislature.go
+++ b/internal/server/iigointernal/legislature.go
@@ -203,7 +203,7 @@ func (l *legislature) updateRules(ruleMatrix rules.RuleMatrix, ruleIsVotedIn boo
 	//notInRulesCache := errors.Errorf("Rule '%v' is not available in rules cache", ruleMatrix)
 	if _, ok := rules.AvailableRules[ruleMatrix.RuleName]; !ok || reflect.DeepEqual(ruleMatrix, rules.AvailableRules[ruleMatrix.RuleName]) { //if the proposed ruleMatrix has the same content as the rule with the same name in AvailableRules, the proposal is for putting a rule in/out of play.
 		if ruleIsVotedIn {
-			err := rules.PullRuleIntoPlay(ruleMatrix.RuleName)
+			err := rules.PullRuleIntoPlayInternal(ruleMatrix.RuleName, l.gameState.RulesInfo.AvailableRules, l.gameState.RulesInfo.CurrentRulesInPlay)
 			if ruleErr, ok := err.(*rules.RuleError); ok {
 				if ruleErr.Type() == rules.RuleNotInAvailableRulesCache {
 					return ruleErr

--- a/internal/server/iigointernal/legislature.go
+++ b/internal/server/iigointernal/legislature.go
@@ -203,14 +203,14 @@ func (l *legislature) updateRules(ruleMatrix rules.RuleMatrix, ruleIsVotedIn boo
 	//notInRulesCache := errors.Errorf("Rule '%v' is not available in rules cache", ruleMatrix)
 	if _, ok := l.gameState.RulesInfo.AvailableRules[ruleMatrix.RuleName]; !ok || reflect.DeepEqual(ruleMatrix, l.gameState.RulesInfo.AvailableRules[ruleMatrix.RuleName]) { //if the proposed ruleMatrix has the same content as the rule with the same name in AvailableRules, the proposal is for putting a rule in/out of play.
 		if ruleIsVotedIn {
-			err := rules.PullRuleIntoPlayInternal(ruleMatrix.RuleName, l.gameState.RulesInfo.AvailableRules, l.gameState.RulesInfo.CurrentRulesInPlay)
+			err := l.gameState.PullRuleIntoPlay(ruleMatrix.RuleName)
 			if ruleErr, ok := err.(*rules.RuleError); ok {
 				if ruleErr.Type() == rules.RuleNotInAvailableRulesCache {
 					return ruleErr
 				}
 			}
 		} else {
-			err := rules.PullRuleOutOfPlayInternal(ruleMatrix.RuleName, l.gameState.RulesInfo.AvailableRules, l.gameState.RulesInfo.CurrentRulesInPlay)
+			err := l.gameState.PullRuleOutOfPlay(ruleMatrix.RuleName)
 			if ruleErr, ok := err.(*rules.RuleError); ok {
 				if ruleErr.Type() == rules.RuleNotInAvailableRulesCache {
 					return ruleErr
@@ -220,7 +220,7 @@ func (l *legislature) updateRules(ruleMatrix rules.RuleMatrix, ruleIsVotedIn boo
 		}
 	} else { //if the proposed ruleMatrix has different content to the rule with the same name in AvailableRules, the proposal is for modifying the rule in the rule caches. It doesn't put a rule in/out of play.
 		if ruleIsVotedIn {
-			err := rules.ModifyRuleInternal(ruleMatrix.RuleName, ruleMatrix.ApplicableMatrix, ruleMatrix.AuxiliaryVector, l.gameState.RulesInfo.AvailableRules, l.gameState.RulesInfo.CurrentRulesInPlay)
+			err := l.gameState.ModifyRule(ruleMatrix.RuleName, ruleMatrix.ApplicableMatrix, ruleMatrix.AuxiliaryVector)
 			return err
 		}
 	}

--- a/internal/server/iigointernal/legislature.go
+++ b/internal/server/iigointernal/legislature.go
@@ -201,7 +201,7 @@ func (l *legislature) updateRules(ruleMatrix rules.RuleMatrix, ruleIsVotedIn boo
 	}
 	//TODO: might want to log the errors as logging messages too?
 	//notInRulesCache := errors.Errorf("Rule '%v' is not available in rules cache", ruleMatrix)
-	if _, ok := rules.AvailableRules[ruleMatrix.RuleName]; !ok || reflect.DeepEqual(ruleMatrix, rules.AvailableRules[ruleMatrix.RuleName]) { //if the proposed ruleMatrix has the same content as the rule with the same name in AvailableRules, the proposal is for putting a rule in/out of play.
+	if _, ok := l.gameState.RulesInfo.AvailableRules[ruleMatrix.RuleName]; !ok || reflect.DeepEqual(ruleMatrix, l.gameState.RulesInfo.AvailableRules[ruleMatrix.RuleName]) { //if the proposed ruleMatrix has the same content as the rule with the same name in AvailableRules, the proposal is for putting a rule in/out of play.
 		if ruleIsVotedIn {
 			err := rules.PullRuleIntoPlayInternal(ruleMatrix.RuleName, l.gameState.RulesInfo.AvailableRules, l.gameState.RulesInfo.CurrentRulesInPlay)
 			if ruleErr, ok := err.(*rules.RuleError); ok {

--- a/internal/server/iigointernal/legislature.go
+++ b/internal/server/iigointernal/legislature.go
@@ -220,7 +220,7 @@ func (l *legislature) updateRules(ruleMatrix rules.RuleMatrix, ruleIsVotedIn boo
 		}
 	} else { //if the proposed ruleMatrix has different content to the rule with the same name in AvailableRules, the proposal is for modifying the rule in the rule caches. It doesn't put a rule in/out of play.
 		if ruleIsVotedIn {
-			err := rules.ModifyRule(ruleMatrix.RuleName, ruleMatrix.ApplicableMatrix, ruleMatrix.AuxiliaryVector)
+			err := rules.ModifyRuleInternal(ruleMatrix.RuleName, ruleMatrix.ApplicableMatrix, ruleMatrix.AuxiliaryVector, l.gameState.RulesInfo.AvailableRules, l.gameState.RulesInfo.CurrentRulesInPlay)
 			return err
 		}
 	}

--- a/internal/server/iigointernal/legislature.go
+++ b/internal/server/iigointernal/legislature.go
@@ -210,7 +210,7 @@ func (l *legislature) updateRules(ruleMatrix rules.RuleMatrix, ruleIsVotedIn boo
 				}
 			}
 		} else {
-			err := rules.PullRuleOutOfPlay(ruleMatrix.RuleName)
+			err := rules.PullRuleOutOfPlayInternal(ruleMatrix.RuleName, l.gameState.RulesInfo.AvailableRules, l.gameState.RulesInfo.CurrentRulesInPlay)
 			if ruleErr, ok := err.(*rules.RuleError); ok {
 				if ruleErr.Type() == rules.RuleNotInAvailableRulesCache {
 					return ruleErr

--- a/internal/server/iigointernal/legislature_test.go
+++ b/internal/server/iigointernal/legislature_test.go
@@ -33,13 +33,18 @@ func genRuleMatrixExample2(ruleName string) rules.RuleMatrix {
 	return rules.RuleMatrix{RuleName: ruleName, ApplicableMatrix: *coreMatrix2, AuxiliaryVector: *auxiliaryVector2, Mutable: true, RequiredVariables: requiredVariables}
 }
 func TestRuleVotedIn(t *testing.T) {
-	rules.AvailableRules, rules.RulesInPlay = generateRulesTestStores()
+	avail, inPlay := generateRulesTestStores()
 	fakeGameState := gamestate.GameState{
 		CommonPool: 400,
 		IIGORolesBudget: map[shared.Role]shared.Resources{
 			shared.President: 10,
 			shared.Speaker:   10,
 			shared.Judge:     10,
+		},
+		RulesInfo: gamestate.RulesContext{
+			VariableMap:        nil,
+			AvailableRules:     avail,
+			CurrentRulesInPlay: inPlay,
 		},
 	}
 	s := legislature{
@@ -89,20 +94,25 @@ func TestRuleVotedIn(t *testing.T) {
 		"Kinda Test Rule":   genRuleMatrixExample1("Kinda Test Rule"),
 		"Kinda Test Rule 2": genRuleMatrixExample1("Kinda Test Rule 2"),
 	}
-	eq := reflect.DeepEqual(rules.RulesInPlay, expectedRulesInPlay)
+	eq := reflect.DeepEqual(inPlay, expectedRulesInPlay)
 	if !eq {
-		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, rules.RulesInPlay)
+		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, inPlay)
 	}
 }
 
 func TestRuleVotedOut(t *testing.T) {
-	rules.AvailableRules, rules.RulesInPlay = generateRulesTestStores()
+	avail, inPlay := generateRulesTestStores()
 	fakeGameState := gamestate.GameState{
 		CommonPool: 400,
 		IIGORolesBudget: map[shared.Role]shared.Resources{
 			shared.President: 10,
 			shared.Speaker:   10,
 			shared.Judge:     10,
+		},
+		RulesInfo: gamestate.RulesContext{
+			VariableMap:        nil,
+			AvailableRules:     avail,
+			CurrentRulesInPlay: inPlay,
 		},
 	}
 	s := legislature{
@@ -149,20 +159,25 @@ func TestRuleVotedOut(t *testing.T) {
 		})
 	}
 	expectedRulesInPlay := map[string]rules.RuleMatrix{}
-	eq := reflect.DeepEqual(rules.RulesInPlay, expectedRulesInPlay)
+	eq := reflect.DeepEqual(inPlay, expectedRulesInPlay)
 	if !eq {
-		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, rules.RulesInPlay)
+		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, inPlay)
 	}
 }
 
 func TestModifiedRuleVotedIn(t *testing.T) {
-	rules.AvailableRules, rules.RulesInPlay = generateRulesTestStores()
+	avail, inPlay := generateRulesTestStores()
 	fakeGameState := gamestate.GameState{
 		CommonPool: 400,
 		IIGORolesBudget: map[shared.Role]shared.Resources{
 			shared.President: 10,
 			shared.Speaker:   10,
 			shared.Judge:     10,
+		},
+		RulesInfo: gamestate.RulesContext{
+			VariableMap:        nil,
+			AvailableRules:     avail,
+			CurrentRulesInPlay: inPlay,
 		},
 	}
 	s := legislature{
@@ -211,9 +226,9 @@ func TestModifiedRuleVotedIn(t *testing.T) {
 	expectedRulesInPlay := map[string]rules.RuleMatrix{
 		"Kinda Test Rule 2": genRuleMatrixExample2("Kinda Test Rule 2"),
 	}
-	eq := reflect.DeepEqual(rules.RulesInPlay, expectedRulesInPlay)
+	eq := reflect.DeepEqual(inPlay, expectedRulesInPlay)
 	if !eq {
-		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, rules.RulesInPlay)
+		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, inPlay)
 	}
 	expectedAvailbleRules := map[string]rules.RuleMatrix{
 		"Kinda Test Rule":   genRuleMatrixExample2("Kinda Test Rule"),
@@ -222,20 +237,25 @@ func TestModifiedRuleVotedIn(t *testing.T) {
 		"TestingRule1":      genRuleMatrixExample1("TestingRule1"),
 		"TestingRule2":      genRuleMatrixExample1("TestingRule2"),
 	}
-	eq = reflect.DeepEqual(rules.AvailableRules, expectedAvailbleRules)
+	eq = reflect.DeepEqual(avail, expectedAvailbleRules)
 	if !eq {
-		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedAvailbleRules, rules.AvailableRules)
+		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedAvailbleRules, avail)
 	}
 }
 
 func TestModifiedRuleVotedOut(t *testing.T) {
-	rules.AvailableRules, rules.RulesInPlay = generateRulesTestStores()
+	avail, inPlay := generateRulesTestStores()
 	fakeGameState := gamestate.GameState{
 		CommonPool: 400,
 		IIGORolesBudget: map[shared.Role]shared.Resources{
 			shared.President: 10,
 			shared.Speaker:   10,
 			shared.Judge:     10,
+		},
+		RulesInfo: gamestate.RulesContext{
+			VariableMap:        nil,
+			AvailableRules:     avail,
+			CurrentRulesInPlay: inPlay,
 		},
 	}
 	s := legislature{
@@ -284,9 +304,9 @@ func TestModifiedRuleVotedOut(t *testing.T) {
 	expectedRulesInPlay := map[string]rules.RuleMatrix{
 		"Kinda Test Rule 2": genRuleMatrixExample1("Kinda Test Rule 2"),
 	}
-	eq := reflect.DeepEqual(rules.RulesInPlay, expectedRulesInPlay)
+	eq := reflect.DeepEqual(inPlay, expectedRulesInPlay)
 	if !eq {
-		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, rules.RulesInPlay)
+		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedRulesInPlay, inPlay)
 	}
 	expectedAvailbleRules := map[string]rules.RuleMatrix{
 		"Kinda Test Rule":   genRuleMatrixExample1("Kinda Test Rule"),
@@ -295,9 +315,9 @@ func TestModifiedRuleVotedOut(t *testing.T) {
 		"TestingRule1":      genRuleMatrixExample1("TestingRule1"),
 		"TestingRule2":      genRuleMatrixExample1("TestingRule2"),
 	}
-	eq = reflect.DeepEqual(rules.AvailableRules, expectedAvailbleRules)
+	eq = reflect.DeepEqual(avail, expectedAvailbleRules)
 	if !eq {
-		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedAvailbleRules, rules.AvailableRules)
+		t.Errorf("The rules in play are not the same as expected, expected '%v', got '%v'", expectedAvailbleRules, avail)
 	}
 }
 

--- a/internal/server/iigointernal/monitoring.go
+++ b/internal/server/iigointernal/monitoring.go
@@ -83,7 +83,7 @@ func (m *monitor) evaluateCache(roleToMonitorID shared.ClientID, ruleStore map[s
 				if foundRules {
 					rulesAffected = append(rulesAffected, valuesToBeAdded...)
 				}
-				rules.UpdateVariableInternal(variable.VariableName, variable, m.gameState.RulesInfo.VariableMap)
+				m.gameState.UpdateVariable(variable.VariableName, variable)
 			}
 			for _, rule := range rulesAffected {
 				ret := rules.EvaluateRuleFromCaches(rule, ruleStore, m.gameState.RulesInfo.VariableMap)

--- a/internal/server/iigointernal/monitoring.go
+++ b/internal/server/iigointernal/monitoring.go
@@ -41,7 +41,7 @@ func (m *monitor) monitorRole(roleAccountable baseclient.Client) shared.MonitorR
 		decideToMonitor := roleAccountable.MonitorIIGORole(roleName)
 		evaluationResult := false
 		if decideToMonitor {
-			evaluationResult = m.evaluateCache(roleToMonitor, rules.RulesInPlay)
+			evaluationResult = m.evaluateCache(roleToMonitor, m.gameState.RulesInfo.CurrentRulesInPlay)
 		}
 
 		m.Logf("Monitoring of %v result %v ", roleToMonitor, evaluationResult)

--- a/internal/server/iigointernal/monitoring_test.go
+++ b/internal/server/iigointernal/monitoring_test.go
@@ -102,8 +102,8 @@ func TestEvaluateCache(t *testing.T) {
 	}
 	var logging shared.Logger = func(format string, a ...interface{}) {}
 	ruleStore := registerMonitoringTestRule()
-	tempCache := rules.AvailableRules
-	rules.AvailableRules = ruleStore
+	tempCache, _ := rules.InitialRuleRegistration(false)
+	avail := ruleStore
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			monitoring := &monitor{
@@ -111,7 +111,8 @@ func TestEvaluateCache(t *testing.T) {
 				logger:            logging,
 				gameState: &gamestate.GameState{
 					RulesInfo: gamestate.RulesContext{
-						VariableMap: generateDummyVariableCache(),
+						VariableMap:    generateDummyVariableCache(),
+						AvailableRules: avail,
 					},
 				},
 			}
@@ -121,7 +122,7 @@ func TestEvaluateCache(t *testing.T) {
 			}
 		})
 	}
-	rules.AvailableRules = tempCache
+	avail = tempCache
 }
 
 func TestFindRoleToMonitor(t *testing.T) {

--- a/internal/server/iigointernal/orchestration.go
+++ b/internal/server/iigointernal/orchestration.go
@@ -18,7 +18,7 @@ func RunIIGO(logger shared.Logger, g *gamestate.GameState, clientMap *map[shared
 	iIGOClients := *clientMap
 
 	removeDeadBodiesFromOffice(g)
-
+	monitoring.gameState = g
 	monitoring.logger = logger
 	logger("President %v, Speaker %v, Judge %v", g.PresidentID, g.SpeakerID, g.JudgeID)
 
@@ -59,17 +59,17 @@ func RunIIGO(logger shared.Logger, g *gamestate.GameState, clientMap *map[shared
 	}
 
 	// Increments the budget according to increment_budget_role rules
-	PresidentIncRule, ok := rules.RulesInPlay["increment_budget_president"]
+	PresidentIncRule, ok := g.RulesInfo.CurrentRulesInPlay["increment_budget_president"]
 	if ok {
 		PresidentBudgetInc := PresidentIncRule.ApplicableMatrix.At(0, 1)
 		g.IIGORolesBudget[shared.President] += shared.Resources(PresidentBudgetInc)
 	}
-	JudgeIncRule, ok := rules.RulesInPlay["increment_budget_judge"]
+	JudgeIncRule, ok := g.RulesInfo.CurrentRulesInPlay["increment_budget_judge"]
 	if ok {
 		JudgeBudgetInc := JudgeIncRule.ApplicableMatrix.At(0, 1)
 		g.IIGORolesBudget[shared.Judge] += shared.Resources(JudgeBudgetInc)
 	}
-	SpeakerIncRule, ok := rules.RulesInPlay["increment_budget_speaker"]
+	SpeakerIncRule, ok := g.RulesInfo.CurrentRulesInPlay["increment_budget_speaker"]
 	if ok {
 		SpeakerBudgetInc := SpeakerIncRule.ApplicableMatrix.At(0, 1)
 		g.IIGORolesBudget[shared.Speaker] += shared.Resources(SpeakerBudgetInc)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,13 +59,7 @@ func createSOMASServer(
 		forageHistory[t] = make([]foraging.ForagingReport, 0)
 	}
 
-	if gameConfig.IIGOConfig.StartWithRulesInPlay {
-		for ruleName := range rules.AvailableRules {
-			// Result is ignored since we know that the RulesInPlay cache cannot contain any of
-			// these rules (the only error case)
-			_ = rules.PullRuleIntoPlay(ruleName)
-		}
-	}
+	availableRules, rulesInPlay := rules.InitialRuleRegistration(gameConfig.IIGOConfig.StartWithRulesInPlay)
 
 	server := &SOMASServer{
 		clientMap:  clientMap,
@@ -92,8 +86,8 @@ func createSOMASServer(
 			PresidentID: shared.Team3,
 			CommonPool:  gameConfig.InitialCommonPool,
 			RulesInfo: gamestate.RulesContext{
-				AvailableRules:     rules.AvailableRules,
-				CurrentRulesInPlay: rules.RulesInPlay,
+				AvailableRules:     availableRules,
+				CurrentRulesInPlay: rulesInPlay,
 				VariableMap:        rules.InitialVarRegistration(),
 			},
 		},


### PR DESCRIPTION
# Summary

Finished removing global variables, all rules information is contained entirely within RuleContext struct in gamestate or in client local caches.

## Test Plan

Had to modify many tests, all now passing.
