### PR TITLE
[INFRA/CORE] Instantiate new client when server is instantiated

### DIFF
--- a/internal/clients/team1/client.go
+++ b/internal/clients/team1/client.go
@@ -29,7 +29,7 @@ func (st EmotionalState) String() string {
 }
 
 func init() {
-	baseclient.RegisterClient(id, NewClient(id))
+	baseclient.RegisterClientFactory(id, func() baseclient.Client { return NewClient(id) })
 }
 
 type clientConfig struct {

--- a/internal/clients/team2/client.go
+++ b/internal/clients/team2/client.go
@@ -107,7 +107,7 @@ type client struct {
 }
 
 func init() {
-	baseclient.RegisterClient(id, NewClient(id))
+	baseclient.RegisterClientFactory(id, func() baseclient.Client { return NewClient(id) })
 }
 
 // TODO: are we using all of these or can they be removed

--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -13,8 +13,7 @@ const id = shared.Team3
 const printTeam3Logs = false
 
 func init() {
-	ourClient := NewClient(id)
-	baseclient.RegisterClient(id, ourClient)
+	baseclient.RegisterClientFactory(id, func() baseclient.Client { return NewClient(id) })
 }
 
 type client struct {

--- a/internal/clients/team3/clientiitoiifo.go
+++ b/internal/clients/team3/clientiitoiifo.go
@@ -45,7 +45,7 @@ func (c *client) MakeDisasterPrediction() shared.DisasterPredictionInfo {
 	prediction.Confidence = determineConfidence(c.pastDisastersList, meanDisaster, varianceLimit)
 
 	// For MVP, share this prediction with all islands since trust has not yet been implemented
-	trustedIslands := make([]shared.ClientID, len(baseclient.RegisteredClients))
+	trustedIslands := make([]shared.ClientID, len(baseclient.RegisteredClientFactories))
 	for index, id := range shared.TeamIDs {
 		trustedIslands[index] = id
 	}

--- a/internal/clients/team4/client.go
+++ b/internal/clients/team4/client.go
@@ -9,7 +9,7 @@ import (
 const id = shared.Team4
 
 func init() {
-	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
+	baseclient.RegisterClientFactory(id, func() baseclient.Client { return baseclient.NewClient(id) })
 }
 
 type client struct {

--- a/internal/clients/team5/client.go
+++ b/internal/clients/team5/client.go
@@ -9,7 +9,7 @@ import (
 const id = shared.Team5
 
 func init() {
-	baseclient.RegisterClient(id, &client{BaseClient: baseclient.NewClient(id)})
+	baseclient.RegisterClientFactory(id, func() baseclient.Client { return baseclient.NewClient(id) })
 }
 
 type client struct {

--- a/internal/clients/team6/client.go
+++ b/internal/clients/team6/client.go
@@ -29,7 +29,7 @@ type client struct {
 }
 
 func init() {
-	baseclient.RegisterClient(id, NewClient(id))
+	baseclient.RegisterClientFactory(id, func() baseclient.Client { return NewClient(id) })
 }
 
 // ########################

--- a/internal/common/baseclient/helper.go
+++ b/internal/common/baseclient/helper.go
@@ -6,15 +6,19 @@ import (
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 )
 
-// RegisteredClients contain all registered clients, exposed for the server.
-var RegisteredClients = map[shared.ClientID]Client{}
+// ClientFactory is a function that returns a new Client instance.
+type ClientFactory = func() Client
 
-// RegisterClient registers clients into RegisteredClients
-func RegisterClient(id shared.ClientID, c Client) {
+// RegisteredClientFactories contain all registered clients and their respective clientFactories exposed for
+// the server.
+var RegisteredClientFactories = map[shared.ClientID]ClientFactory{}
+
+// RegisterClientFactory registers client factories into RegisteredClientFactories
+func RegisterClientFactory(id shared.ClientID, c ClientFactory) {
 	// prevent double registrations
-	if _, ok := RegisteredClients[id]; ok {
+	if _, ok := RegisteredClientFactories[id]; ok {
 		// OK to panic here, as this is a _crucial_ step.
-		panic(fmt.Sprintf("Duplicate client ID %v in RegisterClient!", id))
+		panic(fmt.Sprintf("Duplicate client ID %v in RegisteredClientFactories!", id))
 	}
-	RegisteredClients[id] = c
+	RegisteredClientFactories[id] = c
 }

--- a/internal/common/baseclient/iifo.go
+++ b/internal/common/baseclient/iifo.go
@@ -50,7 +50,7 @@ func (c *BaseClient) MakeDisasterPrediction() shared.DisasterPredictionInfo {
 	prediction.Confidence = determineConfidence(pastDisastersList, meanDisaster, varianceLimit)
 
 	// For MVP, share this prediction with all islands since trust has not yet been implemented
-	trustedIslands := make([]shared.ClientID, len(RegisteredClients))
+	trustedIslands := make([]shared.ClientID, len(RegisteredClientFactories))
 	for index, id := range shared.TeamIDs {
 		trustedIslands[index] = id
 	}

--- a/internal/common/baseclient/iito.go
+++ b/internal/common/baseclient/iito.go
@@ -85,7 +85,7 @@ func (c *BaseClient) ReceivedGift(received shared.Resources, from shared.ClientI
 func (c *BaseClient) ShareIntendedContribution() shared.IntendedContribution {
 
 	// For MVP, share this prediction with all islands since trust has not yet been implemented
-	trustedIslands := make([]shared.ClientID, len(RegisteredClients))
+	trustedIslands := make([]shared.ClientID, len(RegisteredClientFactories))
 	for index, id := range shared.TeamIDs {
 		trustedIslands[index] = id
 	}

--- a/internal/server/clientreg_test.go
+++ b/internal/server/clientreg_test.go
@@ -10,14 +10,15 @@ import (
 // TestClientReg checks that all clients are registered
 func TestNumClientReg(t *testing.T) {
 	const numTeams = 6 // we have 6 teams
-	numRegClients := len(baseclient.RegisteredClients)
+	numRegClients := len(baseclient.RegisteredClientFactories)
 	if numRegClients != numTeams {
 		t.Errorf("Are all teams registered? want '%v' got '%v'", numTeams, numRegClients)
 	}
 }
 
 func TestClientReg(t *testing.T) {
-	checkClientReg := func(id shared.ClientID, c baseclient.Client) {
+	checkClientReg := func(id shared.ClientID, cf baseclient.ClientFactory) {
+		c := cf()
 		defer func() {
 			if err := recover(); err != nil {
 				t.Errorf("Client %v was registered with a nil baseclient.Client!", id)
@@ -26,7 +27,7 @@ func TestClientReg(t *testing.T) {
 		c.Echo("checking!")
 	}
 
-	for id, client := range baseclient.RegisteredClients {
-		checkClientReg(id, client)
+	for id, cf := range baseclient.RegisteredClientFactories {
+		checkClientReg(id, cf)
 	}
 }


### PR DESCRIPTION
# Summary

- The problem we had with WASM with NaNs (#310) was primarily due to Team 3 producing NaNs when it is a president--`SetTaxationAmount` produces NaNs
- This only occurs in the second run in the same instance, prompting the belief that the global states were causing the issue as the states are preserved.
- However the problem was in the client pointers which were not reinstantiated during a new run on the same instance.
- Changed `RegisterClient` to `RegisterClientFactory` to make sure a fresh client is instantanted upon a new run in `NewSOMASServer`
- Added a `ran` variable inside `SOMASServer` to prevent running `EntryPoint` twice on a dirty `SOMASServer`.

## Additional Info
- Touched agent code to rename references to `RegisteredClients` to `RegisteredClientFactories`.

## Test Plan
- A reliable to repro the bug is to change the final part of `main.go:main()` to the below by adding a for loop looping the game twice. 
- The cmd to repo is `go run . --maxTurns 2`
```
...
	for i := 0; i < 2; i++ { // <<<<<<<<<<<<<<<<<<<<<
		s := server.NewSOMASServer(gameConfig)
		if gameStates, err := s.EntryPoint(); err != nil {
			log.Fatalf("Run failed with: %+v", err)
		} else {
			fmt.Printf("===== GAME CONFIGURATION =====\n")
			fmt.Printf("%#v\n", gameConfig)
			for _, st := range gameStates {
				fmt.Printf("===== START OF TURN %v (END OF TURN %v) =====\n", st.Turn, st.Turn-1)
				fmt.Printf("%#v\n", st)
			}
			timeEnd := time.Now()
			err = outputJSON(output{
				GameStates: gameStates,
				Config:     gameConfig,
				GitInfo:    getGitInfo(),
				AuxInfo:    getAuxInfo(),
				RunInfo: runInfo{
					TimeStart:       timeStart,
					TimeEnd:         timeEnd,
					DurationSeconds: timeEnd.Sub(timeStart).Seconds(),
					Version:         runtime.Version(),
					GOOS:            runtime.GOOS,
					GOARCH:          runtime.GOARCH,
				},
			}, absOutputDir)
			if err != nil {
				log.Fatalf("Failed to output JSON: %v", err)
			}
		}
	} // <<<<<<<<<<<<<<<<<<<<<
...
```

Following this change it is no longer reproducible.