### PR TITLE
[IIGO] (as usual) Caches are reset due to use of syncWithGame

### DIFF
--- a/internal/server/iigointernal/judiciary.go
+++ b/internal/server/iigointernal/judiciary.go
@@ -43,15 +43,6 @@ func (j *judiciary) syncWithGame(gameState *gamestate.GameState, gameConf *confi
 	j.gameConf = gameConf
 }
 
-func (j *judiciary) resetCaches() {
-	if len(j.gameState.IIGOSanctionCache) != int(j.gameConf.SanctionCacheDepth) {
-		j.gameState.IIGOSanctionCache = DefaultInitLocalSanctionCache(int(j.gameConf.SanctionCacheDepth))
-	}
-	if len(j.gameState.IIGOHistoryCache) != int(j.gameConf.HistoryCacheDepth) {
-		j.gameState.IIGOHistoryCache = DefaultInitLocalHistoryCache(int(j.gameConf.HistoryCacheDepth))
-	}
-}
-
 func (j *judiciary) broadcastSanctionConfig() {
 	broadcastGeneric(j.iigoClients, j.JudgeID, createBroadcastsForSanctionThresholds(j.sanctionThresholds), *j.gameState)
 	broadcastGeneric(j.iigoClients, j.JudgeID, createBroadcastsForRuleViolationPenalties(j.ruleViolationSeverity), *j.gameState)

--- a/internal/server/iigointernal/judiciary.go
+++ b/internal/server/iigointernal/judiciary.go
@@ -43,7 +43,6 @@ func (j *judiciary) loadSanctionConfig() {
 func (j *judiciary) syncWithGame(gameState *gamestate.GameState, gameConf *config.IIGOConfig) {
 	j.gameState = gameState
 	j.gameConf = gameConf
-	j.resetCaches()
 }
 
 func (j *judiciary) resetCaches() {
@@ -113,7 +112,6 @@ func (j *judiciary) inspectHistory(iigoHistory []shared.Accountability) (map[sha
 			return nil, false
 		}
 	}
-
 
 	rulesInPlay := j.gameState.RulesInfo.CurrentRulesInPlay
 	if !CheckEnoughInCommonPool(j.gameConf.HistoricalRetributionActionCost, j.gameState) {


### PR DESCRIPTION
# Summary

Removed j.resetCaches from judiciary's syncWithGame.

## Additional Information

syncWithGame wasn't initially intended to be called every turn. It was there to facilitate hot-swapping of game-configs (for some reason I thought that was a thing). Judiciary branch's syncWithGame function also reset its caches, deffo not smth we wanna do each turn.
