### PR TITLE
[INFRA/CORE] Add logging level in CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,12 +31,23 @@ var (
 	outputFolderName = flag.String(
 		"output",
 		"output",
-		"The relative path (to the current working directory) to store output.json and logs in.",
+		"The relative path (to the current working directory) to store output.json and logs in.\n"+
+			"WARNING: This folder will be removed prior to running!",
+	)
+	logLevel = flag.Uint(
+		"logLevel",
+		2,
+		"Logging verbosity level. Note that output artifacts will remain the same.\n"+
+			"0: No logs at all\n"+
+			"1: Game logs (identical to logs.txt) (to stderr)\n"+
+			"2: As in 1 plus game states (similar to output.json) (to stdout)\n",
 	)
 )
 
 func main() {
 	timeStart := time.Now()
+	flag.Parse()
+
 	var err error
 
 	wd, err := os.Getwd()
@@ -44,7 +55,6 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
-	flag.Parse()
 	absOutputDir := path.Join(wd, *outputFolderName)
 
 	err = prepareOutputFolder(absOutputDir)
@@ -64,11 +74,13 @@ func main() {
 	if gameStates, err := s.EntryPoint(); err != nil {
 		log.Fatalf("Run failed with: %+v", err)
 	} else {
-		fmt.Printf("===== GAME CONFIGURATION =====\n")
-		fmt.Printf("%#v\n", gameConfig)
-		for _, st := range gameStates {
-			fmt.Printf("===== START OF TURN %v (END OF TURN %v) =====\n", st.Turn, st.Turn-1)
-			fmt.Printf("%#v\n", st)
+		if *logLevel >= 2 {
+			fmt.Printf("===== GAME CONFIGURATION =====\n")
+			fmt.Printf("%#v\n", gameConfig)
+			for _, st := range gameStates {
+				fmt.Printf("===== START OF TURN %v (END OF TURN %v) =====\n", st.Turn, st.Turn-1)
+				fmt.Printf("%#v\n", st)
+			}
 		}
 		timeEnd := time.Now()
 		err = outputJSON(output{
@@ -113,8 +125,14 @@ func prepareLogger(absOutputDir string) error {
 		return errors.Errorf("Unable to open log file, try running using sudo: %v", err)
 	}
 
+	writers := []io.Writer{f}
+
+	if *logLevel >= 1 {
+		writers = append(writers, os.Stderr)
+	}
+
 	log.SetOutput(
-		logger.NewLogWriter([]io.Writer{os.Stderr, f}),
+		logger.NewLogWriter(writers),
 	)
 
 	return nil


### PR DESCRIPTION
# Summary

Logging slows down running. Add described logging levels possible in CLI flag.

## Additional Info
Add a warning about deletion in `--output` flag.

## Test Plan

Tested with
`go run . --logLevel 0|1|2` -- all behaviour as expected.
