### PR TITLE
[IIGO] Preventing premature elections

### DIFF
--- a/internal/common/rules/globalruleregistration.go
+++ b/internal/common/rules/globalruleregistration.go
@@ -283,7 +283,7 @@ func registerRulesByMass(availableRules map[string]RuleMatrix) map[string]RuleMa
 			Name: "obl_to_propose_rule_if_some_are_given",
 			ReqVar: []VariableFieldName{
 				IslandsProposedRules,
-				RuleSelected,
+				PresidentRuleProposal,
 			},
 			Values:  []float64{1, -1, 0},
 			Aux:     []float64{0},

--- a/internal/server/iigointernal/judiciary.go
+++ b/internal/server/iigointernal/judiciary.go
@@ -227,7 +227,7 @@ func (j *judiciary) scoreIslandTransgressions(transgressions map[shared.ClientID
 			if score, ok := j.ruleViolationSeverity[ruleBroken]; ok {
 				totalIslandTurnScore += score
 			} else {
-				totalIslandTurnScore += shared.IIGOSanctionsScore(1)
+				totalIslandTurnScore += shared.IIGOSanctionsScore(5)
 			}
 			j.Logf("Rule: %v, broken by: %v", ruleBroken, islandID)
 		}
@@ -263,7 +263,7 @@ func (j *judiciary) sanctionEvaluate(reportedIslandResources map[shared.ClientID
 	totalSanctionPerAgent := runEvaluationRulesOnSanctions(j.gameState.IIGOSanctionCache, reportedIslandResources, j.gameState.RulesInfo.CurrentRulesInPlay, j.gameConf.AssumedResourcesNoReport)
 	j.gameState.IIGOSanctionMap = totalSanctionPerAgent
 	for clientID, sanctionedResources := range totalSanctionPerAgent {
-		communicateWithIslands(j.iigoClients, j.JudgeID, clientID, map[shared.CommunicationFieldName]shared.CommunicationContent{
+		communicateWithIslands(j.iigoClients, clientID, j.JudgeID, map[shared.CommunicationFieldName]shared.CommunicationContent{
 			shared.SanctionAmount: {
 				T:           shared.CommunicationInt,
 				IntegerData: int(sanctionedResources),

--- a/internal/server/iigointernal/judiciary_test.go
+++ b/internal/server/iigointernal/judiciary_test.go
@@ -397,7 +397,7 @@ func TestUpdateSanctionScore(t *testing.T) {
 			},
 			expectedIslandScores: map[shared.ClientID]shared.IIGOSanctionsScore{
 				shared.Team1: 100,
-				shared.Team2: 51,
+				shared.Team2: 55,
 				shared.Team3: 100,
 			},
 		},

--- a/internal/server/iigointernal/monitoring.go
+++ b/internal/server/iigointernal/monitoring.go
@@ -45,7 +45,7 @@ func (m *monitor) monitorRole(roleAccountable baseclient.Client) shared.MonitorR
 		}
 
 		if !evaluationResult {
-			m.gameState.IIGOTurnsInPower[roleName] = m.config.IIGOConfig.IIGOTermLengths[roleName]
+			m.gameState.IIGOTurnsInPower[roleName] = m.config.IIGOConfig.IIGOTermLengths[roleName] + 1
 		}
 
 		m.Logf("Monitoring of %v result %v ", roleToMonitor, evaluationResult)

--- a/internal/server/iigointernal/monitoring.go
+++ b/internal/server/iigointernal/monitoring.go
@@ -2,6 +2,7 @@ package iigointernal
 
 import (
 	"fmt"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
@@ -12,6 +13,7 @@ import (
 
 type monitor struct {
 	gameState   *gamestate.GameState
+	config      *config.Config
 	iigoClients map[shared.ClientID]baseclient.Client
 	logger      shared.Logger
 }
@@ -40,6 +42,10 @@ func (m *monitor) monitorRole(roleAccountable baseclient.Client) shared.MonitorR
 		evaluationResult := false
 		if decideToMonitor {
 			evaluationResult = m.evaluateCache(roleToMonitor, m.gameState.RulesInfo.CurrentRulesInPlay)
+		}
+
+		if !evaluationResult {
+			m.gameState.IIGOTurnsInPower[roleName] = m.config.IIGOConfig.IIGOTermLengths[roleName]
 		}
 
 		m.Logf("Monitoring of %v result %v ", roleToMonitor, evaluationResult)

--- a/internal/server/iigointernal/orchestration.go
+++ b/internal/server/iigointernal/orchestration.go
@@ -20,6 +20,7 @@ func RunIIGO(logger shared.Logger, g *gamestate.GameState, clientMap *map[shared
 		gameState:   g,
 		iigoClients: iIGOClients,
 		logger:      logger,
+		config:      gameConf,
 	}
 
 	logger("President %v, Speaker %v, Judge %v", g.PresidentID, g.SpeakerID, g.JudgeID)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"log"
+	"math/rand"
 
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
@@ -94,9 +95,9 @@ func createSOMASServer(
 				shared.Judge:     0,
 				shared.Speaker:   0,
 			},
-			SpeakerID:   shared.Team1,
-			JudgeID:     shared.Team2,
-			PresidentID: shared.Team3,
+			SpeakerID:   shared.ClientID(rand.Intn(len(shared.TeamIDs))),
+			JudgeID:     shared.ClientID(rand.Intn(len(shared.TeamIDs))),
+			PresidentID: shared.ClientID(rand.Intn(len(shared.TeamIDs))),
 			CommonPool:  gameConfig.InitialCommonPool,
 			RulesInfo: gamestate.RulesContext{
 				AvailableRules:     availableRules,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,9 +2,6 @@ package server
 
 import (
 	"fmt"
-	"log"
-	"math/rand"
-
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/disasters"
@@ -14,6 +11,7 @@ import (
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/SOMAS2020/SOMAS2020/internal/server/iigointernal"
 	"github.com/pkg/errors"
+	"log"
 )
 
 // Server represents the primary server interface exposed to the simulation.
@@ -95,9 +93,9 @@ func createSOMASServer(
 				shared.Judge:     0,
 				shared.Speaker:   0,
 			},
-			SpeakerID:   shared.ClientID(rand.Intn(len(shared.TeamIDs))),
-			JudgeID:     shared.ClientID(rand.Intn(len(shared.TeamIDs))),
-			PresidentID: shared.ClientID(rand.Intn(len(shared.TeamIDs))),
+			SpeakerID:   shared.Team1,
+			JudgeID:     shared.Team2,
+			PresidentID: shared.Team3,
 			CommonPool:  gameConfig.InitialCommonPool,
 			RulesInfo: gamestate.RulesContext{
 				AvailableRules:     availableRules,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/config"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/disasters"
@@ -11,7 +13,6 @@ import (
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/SOMAS2020/SOMAS2020/internal/server/iigointernal"
 	"github.com/pkg/errors"
-	"log"
 )
 
 // Server represents the primary server interface exposed to the simulation.

--- a/params.go
+++ b/params.go
@@ -27,7 +27,7 @@ var (
 	)
 	initialCommonPool = flag.Float64(
 		"initialCommonPool",
-		100,
+		1000,
 		"The default number of resources in the common pool at the start of the game.",
 	)
 	costOfLiving = flag.Float64(


### PR DESCRIPTION
# Summary

A number of misc. bugs in IIGO conspired to keep electing out certain roles from office too early. We have fixed this behaviour.

## Additional Information

Pls be very careful around your CallRoleElection implementations, it is quite easy to cause IIGO to accidentally descend into anarchy.
