### PR TITLE
 [INFRA/CORE] Handle invalid values in takeResources, giveResources

### DIFF
--- a/internal/server/forage.go
+++ b/internal/server/forage.go
@@ -161,7 +161,10 @@ func (s *SOMASServer) distributeForageReturn(contributions map[shared.ClientID]s
 			}
 		}
 
-		s.giveResources(participantID, participantReturn, retReason)
+		err := s.giveResources(participantID, participantReturn, retReason)
+		if err != nil {
+			s.logf("Ignoring failure to give resources in distributeForageReturn: %v", err)
+		}
 		s.clientMap[participantID].ForageUpdate(shared.ForageDecision{
 			Type:         huntReport.ForageType,
 			Contribution: contribution,

--- a/internal/server/helper.go
+++ b/internal/server/helper.go
@@ -125,11 +125,16 @@ func (s *SOMASServer) takeResources(clientID shared.ClientID, resources shared.R
 }
 
 // giveResources gives resources to client, logging it and mentioning reason
-func (s *SOMASServer) giveResources(clientID shared.ClientID, resources shared.Resources, reason string) {
-	s.logf("Gave %v to %v (reason: %s)", resources, clientID, reason)
+func (s *SOMASServer) giveResources(clientID shared.ClientID, resources shared.Resources, reason string) error {
+	s.logf("Trying to give %v to %v (reason: %s)", resources, clientID, reason)
+	if math.IsNaN(float64(resources)) || resources < 0 {
+		return errors.Errorf("Cannot give invalid number of resources %v to client %v", resources, clientID)
+	}
 
 	participantInfo := s.gameState.ClientInfos[clientID]
 	participantInfo.Resources += resources
 	s.gameState.ClientInfos[clientID] = participantInfo
 
+	s.logf("Gave %v to %v (reason: %s)", resources, clientID, reason)
+	return nil
 }

--- a/internal/server/helper.go
+++ b/internal/server/helper.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"math"
+
 	"github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/gamestate"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
@@ -104,7 +106,10 @@ func getNonDeadClientIDs(clientInfos map[shared.ClientID]gamestate.ClientInfo) [
 
 // giveResources takes resources to client, logging it and mentioning reason
 func (s *SOMASServer) takeResources(clientID shared.ClientID, resources shared.Resources, reason string) error {
-	s.logf("Took %v from %v (reason: %s)", resources, clientID, reason)
+	s.logf("Trying to take %v from %v (reason: %s)", resources, clientID, reason)
+	if math.IsNaN(float64(resources)) || resources < 0 {
+		return errors.Errorf("Cannot take invalid number of resources %v from client %v", resources, clientID)
+	}
 
 	participantInfo := s.gameState.ClientInfos[clientID]
 	if participantInfo.Resources < resources {
@@ -115,6 +120,7 @@ func (s *SOMASServer) takeResources(clientID shared.ClientID, resources shared.R
 	}
 	participantInfo.Resources -= resources
 	s.gameState.ClientInfos[clientID] = participantInfo
+	s.logf("Took %v from %v (reason: %s)", resources, clientID, reason)
 	return nil
 }
 

--- a/internal/server/helper_test.go
+++ b/internal/server/helper_test.go
@@ -290,6 +290,7 @@ func TestGiveResources(t *testing.T) {
 		resources shared.Resources
 		giveAmt   shared.Resources
 		want      shared.Resources
+		wantErr   error
 	}{
 		{
 			name:      "normal",
@@ -303,6 +304,22 @@ func TestGiveResources(t *testing.T) {
 			giveAmt:   0,
 			want:      42,
 		},
+		{
+			name:      "Give NaN",
+			resources: 42,
+			giveAmt:   shared.Resources(math.NaN()),
+			want:      42,
+			wantErr: errors.Errorf("Cannot give invalid number of resources %v to client %v",
+				math.NaN(), shared.Team1),
+		},
+		{
+			name:      "Give -42",
+			resources: 42,
+			giveAmt:   -42,
+			want:      42,
+			wantErr: errors.Errorf("Cannot give invalid number of resources %v to client %v",
+				-42, shared.Team1),
+		},
 	}
 
 	for _, tc := range cases {
@@ -315,8 +332,10 @@ func TestGiveResources(t *testing.T) {
 				},
 			}
 
-			s.giveResources(shared.Team1, tc.giveAmt, tc.name)
+			err := s.giveResources(shared.Team1, tc.giveAmt, tc.name)
 			got := s.gameState.ClientInfos[shared.Team1].Resources
+
+			testutils.CompareTestErrors(tc.wantErr, err, t)
 
 			if tc.want != got {
 				t.Errorf("want '%v' got '%v'", tc.want, got)

--- a/internal/server/helper_test.go
+++ b/internal/server/helper_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -242,6 +243,22 @@ func TestTakeResources(t *testing.T) {
 			takeAmt:   15,
 			want:      10,
 			wantErr:   errors.Errorf("Client %v did not have enough resources. Requested %v, only had %v", shared.Team1, 15, 10),
+		},
+		{
+			name:      "NaN",
+			resources: 42,
+			takeAmt:   shared.Resources(math.NaN()),
+			want:      42,
+			wantErr: errors.Errorf("Cannot take invalid number of resources %v from client %v",
+				math.NaN(), shared.Team1),
+		},
+		{
+			name:      "try take negative",
+			resources: 42,
+			takeAmt:   shared.Resources(-42),
+			want:      42,
+			wantErr: errors.Errorf("Cannot take invalid number of resources %v from client %v",
+				-42, shared.Team1),
 		},
 	}
 

--- a/internal/server/iigo.go
+++ b/internal/server/iigo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/SOMAS2020/SOMAS2020/internal/common/rules"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 	"github.com/SOMAS2020/SOMAS2020/internal/server/iigointernal"
+	"github.com/pkg/errors"
 )
 
 // runIIGO : IIGO decides rule changes, elections, sanctions
@@ -89,7 +90,10 @@ func (s *SOMASServer) runIIGOAllocations() error {
 		allocation := v.RequestAllocation()
 
 		if allocation <= s.gameState.CommonPool {
-			s.giveResources(clientID, allocation, "allocation")
+			err := s.giveResources(clientID, allocation, "allocation")
+			if err != nil {
+				return errors.Errorf("Failed to give resources: %v", err)
+			}
 			s.gameState.CommonPool -= allocation
 
 			s.updateIIGOHistoryAndRules(clientID, []rules.VariableValuePair{

--- a/internal/server/iito.go
+++ b/internal/server/iito.go
@@ -244,7 +244,10 @@ func (s *SOMASServer) executeTransactions(transactions map[shared.ClientID]share
 			if errTake != nil {
 				s.logf("[IITO]: Error deducting amount: %v", errTake)
 			} else {
-				s.giveResources(toTeam, giftAmount, "GIVE: "+transactionMsg)
+				err := s.giveResources(toTeam, giftAmount, "GIVE: "+transactionMsg)
+				if err != nil {
+					s.logf("Ignoring failure to give resources in executeTransactions: %v", err)
+				}
 				s.clientMap[toTeam].ReceivedGift(giftAmount, fromTeam)
 				s.clientMap[fromTeam].SentGift(giftAmount, toTeam)
 			}


### PR DESCRIPTION
# Summary
As title. Handle `NaN`s and negative values because _no one can be trusted_.

## Additional Information

Handled errors from `giveResources` by logging when error return is not available, returning a wrapped error otherwise.

## Test Plan

In CI we trust.