### PR TITLE
Minor feat: updated forageReport to include participant contributions

### DIFF
--- a/internal/common/foraging/helpers.go
+++ b/internal/common/foraging/helpers.go
@@ -11,6 +11,7 @@ import (
 // ForagingReport holds information about the result of a foraging session
 type ForagingReport struct {
 	ForageType               shared.ForageType
+	InputResources         shared.Resources // combined input resources
 	ParticipantContributions map[shared.ClientID]shared.Resources
 	NumberCaught             uint             // number of deer/fish/... caught
 	TotalUtility             shared.Resources // total return of foraging session before distribution

--- a/internal/common/foraging/helpers.go
+++ b/internal/common/foraging/helpers.go
@@ -34,6 +34,7 @@ func compileForagingReport(
 
 	fR := ForagingReport{
 		ForageType:               forageType,
+	        InputResources:           getTotalInput(contribs),
 		ParticipantContributions: contribs,
 		CatchSizes:               make([]float64, 0),
 	}

--- a/internal/common/foraging/helpers.go
+++ b/internal/common/foraging/helpers.go
@@ -10,13 +10,12 @@ import (
 
 // ForagingReport holds information about the result of a foraging session
 type ForagingReport struct {
-	ForageType         shared.ForageType
-	InputResources     shared.Resources // combined input resources
-	NumberParticipants uint             // number of participants in foraging session
-	NumberCaught       uint             // number of deer/fish/... caught
-	TotalUtility       shared.Resources // total return of foraging session before distribution
-	CatchSizes         []float64        // sizes/weights of individual deer/fish/... caught
-	Turn               uint             // turn in which this report was generated. Should be populated by caller
+	ForageType               shared.ForageType
+	ParticipantContributions map[shared.ClientID]shared.Resources
+	NumberCaught             uint             // number of deer/fish/... caught
+	TotalUtility             shared.Resources // total return of foraging session before distribution
+	CatchSizes               []float64        // sizes/weights of individual deer/fish/... caught
+	Turn                     uint             // turn in which this report was generated. Should be populated by caller
 }
 
 func getTotalInput(contribs map[shared.ClientID]shared.Resources) shared.Resources {
@@ -33,10 +32,9 @@ func compileForagingReport(
 	forageReturns []shared.Resources) ForagingReport {
 
 	fR := ForagingReport{
-		ForageType:         forageType,
-		InputResources:     getTotalInput(contribs),
-		NumberParticipants: uint(len(contribs)),
-		CatchSizes:         make([]float64, 0),
+		ForageType:               forageType,
+		ParticipantContributions: contribs,
+		CatchSizes:               make([]float64, 0),
 	}
 	for _, r := range forageReturns {
 		fR.TotalUtility += r

--- a/internal/server/forage.go
+++ b/internal/server/forage.go
@@ -129,7 +129,15 @@ func (s *SOMASServer) runDeerHunt(contributions map[shared.ClientID]shared.Resou
 
 func (s *SOMASServer) distributeForageReturn(contributions map[shared.ClientID]shared.Resources, huntReport foraging.ForagingReport) {
 	// distribute return amongst participants
-	totalContributions := huntReport.InputResources
+
+	totalContributions := shared.Resources(0)
+	for _, c := range huntReport.ParticipantContributions {
+		totalContributions += c
+	}
+
+	if len(huntReport.ParticipantContributions) == 0 {
+		return // to prevent div0 below. Also, no need to evaluate further
+	}
 
 	// auxiliary return info. Just to avoid repetition.
 	type auxReturnInfo struct {
@@ -156,7 +164,7 @@ func (s *SOMASServer) distributeForageReturn(contributions map[shared.ClientID]s
 				case shared.InputProportionalSplit:
 					participantReturn = (contribution / totalContributions) * huntReport.TotalUtility
 				case shared.EqualSplit, shared.RankProportionalSplit: // RankProportional is just same as equal split for now
-					participantReturn = huntReport.TotalUtility / shared.Resources(huntReport.NumberParticipants) // this casting is a bit lazy
+					participantReturn = huntReport.TotalUtility / shared.Resources(len(huntReport.ParticipantContributions)) // this casting is a bit lazy
 				}
 			}
 		}


### PR DESCRIPTION
# Summary

As requested by big unit @Eirikalb. Small change to include input contributions into `forageReport` that's stored in `foragingHistory` in game state so that we can viz individual foraging ROI for each agent

## Additional Information

If only agents could see this :') 

Also, 99% sure it doesn't break anything but like 2020 showed us, anything's possible.

## Test Plan

- no