### PR TITLE
[TEAM 1] (Totally legit team 1 person) Fixing the thing I was supposed to fix earlier 

### DIFF
--- a/internal/clients/team1/iigo.go
+++ b/internal/clients/team1/iigo.go
@@ -160,6 +160,11 @@ func (c *client) RequestAllocation() shared.Resources {
 		)
 	}
 
+	c.LocalVariableCache[rules.IslandAllocation] = rules.VariableValuePair{
+		VariableName: rules.IslandAllocation,
+		Values:       []float64{float64(c.ServerReadHandle.GetGameState().CommonPool)},
+	}
+
 	allocationPair, success := c.GetRecommendation(rules.IslandAllocation)
 	if !success {
 		c.Logf("Cannot determine allocation, trying to get all resources in CP.")


### PR DESCRIPTION
# Summary

So the allocation rule is fine with you paying 0 allocation whatever you were actually allocated. So GetRecommendation was ok with that too. By setting the IslandAllocaiton to the entire common pool (like you guys did earlier) We can force the GetRecommendation to find the actual amount we need to pay.


