### PR TITLE
[IIGO/Vis] Fixed tax and allocation updates

### DIFF
--- a/internal/common/gamestate/gamestate.go
+++ b/internal/common/gamestate/gamestate.go
@@ -45,6 +45,9 @@ type GameState struct {
 	// IIGO Allocation Amount Map
 	IIGOAllocationMap map[shared.ClientID]shared.Resources
 
+	// IIGO Allocation Made
+	IIGOAllocationMade bool
+
 	// IIGO Sanction Amount Map
 	IIGOSanctionMap map[shared.ClientID]shared.Resources
 

--- a/internal/server/iigo.go
+++ b/internal/server/iigo.go
@@ -86,6 +86,7 @@ func (s *SOMASServer) runIIGOAllocations() error {
 	s.logf("start runIIGOAllocations")
 	defer s.logf("finish runIIGOAllocations")
 	clientMap := getNonDeadClients(s.gameState.ClientInfos, s.clientMap)
+	allocationMap := make(map[shared.ClientID]shared.Resources)
 	for clientID, v := range clientMap {
 		allocation := v.RequestAllocation()
 
@@ -96,18 +97,39 @@ func (s *SOMASServer) runIIGOAllocations() error {
 			}
 			s.gameState.CommonPool -= allocation
 
-			s.updateIIGOHistoryAndRules(clientID, []rules.VariableValuePair{
-				{
-					VariableName: rules.IslandAllocation,
-					Values:       []float64{float64(allocation)},
-				},
-				{
-					VariableName: rules.ExpectedAllocation,
-					Values:       []float64{float64(s.gameState.IIGOAllocationMap[clientID])},
-				},
-			})
+			if s.gameState.IIGOAllocationMade {
+				s.updateIIGOHistoryAndRules(clientID, []rules.VariableValuePair{
+					{
+						VariableName: rules.IslandAllocation,
+						Values:       []float64{float64(allocation)},
+					},
+					{
+						VariableName: rules.ExpectedAllocation,
+						Values:       []float64{float64(s.gameState.IIGOAllocationMap[clientID])},
+					},
+				})
+			} else {
+				allocationMap[clientID] = allocation
+				//Allow islands to take what they want if no allocations made
+				s.updateIIGOHistoryAndRules(clientID, []rules.VariableValuePair{
+					{
+						VariableName: rules.IslandAllocation,
+						Values:       []float64{float64(allocation)},
+					},
+					{
+						VariableName: rules.ExpectedAllocation,
+						Values:       []float64{float64(allocation)},
+					},
+				})
+
+			}
 
 		}
+	}
+
+	//Update gamestate for visualisation
+	if !s.gameState.IIGOAllocationMade {
+		s.gameState.IIGOAllocationMap = allocationMap
 	}
 	return nil
 }

--- a/internal/server/iigointernal/executive.go
+++ b/internal/server/iigointernal/executive.go
@@ -119,13 +119,11 @@ func (e *executive) broadcastTaxation(islandsResources map[shared.ClientID]share
 		}
 		e.Logf("Tax: %v", taxMapReturn.ResourceMap)
 	} else {
-		// default case when president doesn't take an action. send tax = 0
-		taxAmountMap := make(map[shared.ClientID]shared.Resources)
+		// default case when president doesn't take an action. Update gamestate with tax = 0
 		for _, islandID := range aliveIslands {
-			taxAmountMap[islandID] = shared.Resources(0)
 			e.sendNoDecision(islandID, shared.IIGOTaxDecision)
 		}
-		e.gameState.IIGOTaxAmount = taxAmountMap
+		e.gameState.IIGOTaxAmount = make(map[shared.ClientID]shared.Resources)
 	}
 
 	return nil


### PR DESCRIPTION
# Summary
If IIGO broadcastTaxation does not run for any reason, the gamestate(and by extension IIGOHistory) is updated with 0 values to reflect this. Zero value means that the island can contribute any amount it decides since tax is a minimum.

If IIGO replyAllocationRequests does not run for any reason, the gamestate reflects this in IIGOAllocationsMade bool. This bool is used in runIIGOAllocations to update the IIGOAllocationMap and IIGOHistory with how much the agents actually take. No allocation means that agents are allowed to take whatever they wish, hence the values are set to how much they actually take.

## Test Plan

Tests still pass
