### PR TITLE
[INFRA/CORE] Unrevert #431 + Limit CI+CD maxTurns to 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run
-      run: go run .
+      run: go run . --maxTurns=20 # fight OOM error
     - name: Output output.json
       run: cat output/output.json
     - name: Install yarn 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,12 @@ jobs:
     - name: Test
       run: go test ./...
     - name: Run
-      run: go run .
+      run: go run . --maxTurns=20 # fight OOM error
     - name: Output output.json
       run: cat output/output.json
     - name: Install yarn 
       run: npm i -g yarn  
-    - name: Cache node_modules #speed things up significantly
+    - name: Cache node_modules # speed things up significantly
       id: cache-node-modules
       uses: actions/cache@v2
       with:

--- a/params.go
+++ b/params.go
@@ -22,12 +22,12 @@ var (
 	)
 	initialResources = flag.Float64(
 		"initialResources",
-		100,
+		50,
 		"The default number of resources at the start of the game.",
 	)
 	initialCommonPool = flag.Float64(
 		"initialCommonPool",
-		1000,
+		0,
 		"The default number of resources in the common pool at the start of the game.",
 	)
 	costOfLiving = flag.Float64(
@@ -52,12 +52,12 @@ var (
 	// config.ForagingConfig.DeerHuntConfig
 	foragingDeerMaxPerHunt = flag.Uint(
 		"foragingMaxDeerPerHunt",
-		4,
+		5,
 		"Max possible number of deer on a single hunt (regardless of number of participants). ** should be strictly less than max deer population.",
 	)
 	foragingDeerIncrementalInputDecay = flag.Float64(
 		"foragingDeerIncrementalInputDecay",
-		0.8,
+		0.9,
 		"Determines decay of incremental input cost of hunting more deer.",
 	)
 	foragingDeerBernoulliProb = flag.Float64(
@@ -67,12 +67,12 @@ var (
 	)
 	foragingDeerExponentialRate = flag.Float64(
 		"foragingDeerExponentialRate",
-		1,
+		0.3,
 		"`lambda` param in W variable (see foraging README). Controls distribution of deer sizes.",
 	)
 	foragingDeerInputScaler = flag.Float64(
 		"foragingDeerInputScaler",
-		12,
+		18,
 		"scalar value that adjusts deer input resources to be in a range that is commensurate with cost of living, salaries etc.",
 	)
 	foragingDeerOutputScaler = flag.Float64(
@@ -87,54 +87,54 @@ var (
 	)
 	foragingDeerThetaCritical = flag.Float64(
 		"foragingDeerThetaCritical",
-		0.8,
+		0.97,
 		"Bernoulli prob of catching deer when population ratio = running population/max deer per hunt = 1",
 	)
 	foragingDeerThetaMax = flag.Float64(
 		"foragingDeerThetaMax",
-		0.95,
+		0.99,
 		"Bernoulli prob of catching deer when population is at carrying capacity (max population)",
 	)
 	foragingDeerMaxPopulation = flag.Uint(
 		"foragingDeerMaxPopulation",
-		12,
+		20,
 		"Max possible deer population. ** Should be strictly greater than max deer per hunt.",
 	)
 	foragingDeerGrowthCoefficient = flag.Float64(
 		"foragingDeerGrowthCoefficient",
-		0.2,
+		0.4,
 		"Scaling parameter used in the population model. Larger coeff => deer pop. regenerates faster.",
 	)
 
 	// config.ForagingConfig.FishingConfig
 	foragingFishMaxPerHunt = flag.Uint(
 		"foragingMaxFishPerHunt",
-		6,
+		12,
 		"Max possible catch (num. fish) on a single expedition (regardless of number of participants).",
 	)
 	foragingFishingIncrementalInputDecay = flag.Float64(
 		"foragingFishingIncrementalInputDecay",
-		0.8,
+		0.95,
 		"Determines decay of incremental input cost of catching more fish.",
 	)
 	foragingFishingMean = flag.Float64(
 		"foragingFishingMean",
-		0.9,
+		1.45,
 		"Determines mean of normal distribution of fishing return (see foraging README)",
 	)
 	foragingFishingVariance = flag.Float64(
 		"foragingFishingVariance",
-		0.2,
+		0.1,
 		"Determines variance of normal distribution of fishing return (see foraging README)",
 	)
 	foragingFishingInputScaler = flag.Float64(
 		"foragingFishingInputScaler",
-		10,
+		18,
 		"scalar value that adjusts input resources to be in a range that is commensurate with cost of living, salaries etc.",
 	)
 	foragingFishingOutputScaler = flag.Float64(
 		"foragingFishingOutputScaler",
-		12,
+		18,
 		"scalar value that adjusts returns to be in a range that is commensurate with cost of living, salaries etc.",
 	)
 	foragingFishingDistributionStrategy = flag.Int(
@@ -166,7 +166,7 @@ var (
 	)
 	disasterPeriod = flag.Uint(
 		"disasterPeriod",
-		15,
+		5,
 		"Period T between disasters in deterministic case and E[T] in stochastic case.",
 	)
 	disasterSpatialPDFType = flag.Int(
@@ -181,12 +181,12 @@ var (
 	)
 	disasterMagnitudeResourceMultiplier = flag.Float64(
 		"disasterMagnitudeResourceMultiplier",
-		500,
+		85,
 		"Multiplier to map disaster magnitude to CP resource deductions",
 	)
 	disasterCommonpoolThreshold = flag.Float64(
 		"disasterCommonpoolThreshold",
-		50,
+		200,
 		"Common pool threshold value for disaster to be mitigated",
 	)
 	disasterStochasticPeriod = flag.Bool(

--- a/website/src/components/CIOutput/CIOutput.tsx
+++ b/website/src/components/CIOutput/CIOutput.tsx
@@ -11,6 +11,7 @@ const CIOutput = () => {
   return (
     <div style={{ paddingTop: 24 }}>
       <h1>CI Output</h1>
+      <p>Note that max turns is set to 20</p>
       <h3 style={{ marginTop: 24 }}>Artifacts</h3>
       <Artifacts output={outputJSON} logs={processedOutputLog} />
 


### PR DESCRIPTION
# Summary

- Website builds ran into OOM since #431 which increased the size the artifacts.
- #431 reverted in #433. Now unreverting.
- This affects both `yarn start` and `yarn build`.
```
$ react-scripts build
Creating an optimized production build...

<--- Last few GCs --->

[3424:0x4a54b80]    91970 ms: Mark-sweep (reduce) 1840.6 (1878.3) -> 1840.0 (1877.5) MB, 1845.2 / 0.0 ms  (average mu = 0.745, current mu = 0.000) last resort GC in old space requested
[3424:0x4a54b80]    93845 ms: Mark-sweep (reduce) 1840.0 (1849.5) -> 1840.0 (1849.5) MB, 1874.4 / 0.0 ms  (average mu = 0.577, current mu = 0.000) last resort GC in old space requested


<--- JS stacktrace --->

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
...
```
- Reduce maxTurns in CI+CD to 20
- Add a warning
![image](https://user-images.githubusercontent.com/33488131/104457136-88506d80-55a1-11eb-9d82-23843a98e6d1.png)


## Additional Info
- Added test for `website/build/index.html` file to double confirm build. `react-scripts` does not error out when OOM.

## Test Plan

`yarn start` and `yarn build` works now.

