### PR TITLE
[INFRA/CORE] Add check for index.html to confirm build success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         cd website
         yarn build
+        test -f build/index.html
     - name: Deploy website
       uses: Cecilapp/GitHub-Pages-deploy@v3
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,4 +44,5 @@ jobs:
         cd website
         yarn test
         yarn build
-        yarn lint         
+        yarn lint 
+        test -f build/index.html


### PR DESCRIPTION
#431 in react-scripts build silently fails with OOM. 

Quick patch to test existence of `website/build/index.html`, which is not produced by a silently failing build.